### PR TITLE
[FEAT]게시물 좋아요 취소 API

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
@@ -2,13 +2,10 @@ package com.dontbe.www.DontBeServer.api.comment.controller;
 
 import com.dontbe.www.DontBeServer.api.comment.dto.request.CommentPostRequestDto;
 import com.dontbe.www.DontBeServer.api.comment.service.CommentCommendService;
-import com.dontbe.www.DontBeServer.api.member.service.MemberService;
 import com.dontbe.www.DontBeServer.common.response.ApiResponse;
-import com.dontbe.www.DontBeServer.common.response.SuccessStatus;
 import com.dontbe.www.DontBeServer.common.util.MemberUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
@@ -45,4 +45,11 @@ public class ContentController {
         contentCommandService.likeContent(memberId, contentId,contentLikedRequestDto);
         return ApiResponse.success(CONTENT_LIKE_SUCCESS);
     }
+
+    @DeleteMapping("content/{contentId}/unliked")
+    public ResponseEntity<ApiResponse<Object>> unlikeContent(Principal principal, @PathVariable("contentId") Long contentId) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        contentCommandService.unlikeContent(memberId, contentId);
+        return ApiResponse.success(CONTENT_UNLIKE_SUCCESS);
+    }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/repository/ContentLikedRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/repository/ContentLikedRepository.java
@@ -9,4 +9,6 @@ public interface ContentLikedRepository extends JpaRepository<ContentLiked,Long>
     boolean existsByContentAndMember(Content content, Member member);
 
     int countByContent(Content content);
+
+    void deleteByContentAndMember(Content content, Member member);
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
@@ -65,6 +65,21 @@ public class ContentCommandService {
         Notification savedNotification = notificationRepository.save(notification);
     }
 
+    public void unlikeContent(Long memberId, Long contentId) {
+        Member triggerMember = memberRepository.findMemberByIdOrThrow(memberId);
+        Content content = contentRepository.findContentByIdOrThrow(contentId);
+
+        if(!contentLikedRepository.existsByContentAndMember(content,triggerMember)){
+            throw new BadRequestException(ErrorStatus.UNEXITST_CONTENT_LIKE.getMessage());
+        }
+
+        contentLikedRepository.deleteByContentAndMember(content,triggerMember);
+
+        Member targetMember = contentRepository.findContentByIdOrThrow(contentId).getMember();
+
+        notificationRepository.deleteByNotificationTargetMemberAndNotificationTriggerMemberIdAndNotificationTriggerTypeAndNotificationTriggerId(
+                targetMember, memberId, "contentLiked", contentId);
+    }
 
     private void deleteValidate(Long memberId, Long contentId) {
         Content content = contentRepository.findById(contentId)

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentQueryService.java
@@ -8,13 +8,10 @@ import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
 import com.dontbe.www.DontBeServer.api.ghost.repository.GhostRepository;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
-import com.dontbe.www.DontBeServer.common.util.TimeUtil;
+import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -33,7 +30,7 @@ public class ContentQueryService {
         Long writerMemberId = content.getMember().getId();
         boolean isGhost = ghostRepository.existsByGhostTargetMemberIdAndGhostTriggerMemberId(writerMemberId, memberId);
         boolean isLiked = contentLikedRepository.existsByContentAndMember(content,member);
-        String time = TimeUtil.refineTime(content.getCreatedAt());
+        String time = TimeUtilCustom.refineTime(content.getCreatedAt());
         int likedNumber = contentLikedRepository.countByContent(content);
         int commentNumber = commentRepository.countByContent(content);
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentQueryService.java
@@ -8,6 +8,7 @@ import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
 import com.dontbe.www.DontBeServer.api.ghost.repository.GhostRepository;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
+import com.dontbe.www.DontBeServer.common.util.TimeUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,9 +33,7 @@ public class ContentQueryService {
         Long writerMemberId = content.getMember().getId();
         boolean isGhost = ghostRepository.existsByGhostTargetMemberIdAndGhostTriggerMemberId(writerMemberId, memberId);
         boolean isLiked = contentLikedRepository.existsByContentAndMember(content,member);
-        LocalDateTime contentTime = content.getCreatedAt();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        String time = contentTime.format(formatter);
+        String time = TimeUtil.refineTime(content.getCreatedAt());
         int likedNumber = contentLikedRepository.countByContent(content);
         int commentNumber = commentRepository.countByContent(content);
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
@@ -1,7 +1,11 @@
 package com.dontbe.www.DontBeServer.api.notification.repository;
 
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    void deleteByNotificationTargetMemberAndNotificationTriggerMemberIdAndNotificationTriggerTypeAndNotificationTriggerId(
+            Member notificaitonTargetMember, Long notificationTriggerMemberId, String notificationTriggerType, Long notificationTriggerId
+    );
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
@@ -17,6 +17,7 @@ public enum ErrorStatus {
     INVALID_MEMBER("유효하지 않은 유저입니다."),
     ANOTHER_ACCESS_TOKEN("지원하지 않는 소셜 플랫폼입니다."),
     DUPLICATION_CONTENT_LIKE("이미 좋아요를 누른 게시물입니다."),
+    UNEXITST_CONTENT_LIKE("좋아요를 누르지 않은 게시물입니다."),
     /**
      * 401 UNAUTHORIZED
      */

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
@@ -24,6 +24,7 @@ public enum SuccessStatus {
     GET_CONTENT_DETAIL_SUCCESS(HttpStatus.OK, "게시물 상세 조회 성공"),
     POST_CONTENT_SUCCESS(HttpStatus.CREATED,"게시글 작성 성공"),
     DELETE_CONTENT_SUCCESS(HttpStatus.OK,"게시글 삭제 성공"),
+    CONTENT_UNLIKE_SUCCESS(HttpStatus.OK,"게시글 좋아요 취소 성공"),
 
     /**
      * comment

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/util/TimeUtil.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/util/TimeUtil.java
@@ -1,0 +1,14 @@
+package com.dontbe.www.DontBeServer.common.util;
+
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@RequiredArgsConstructor
+public class TimeUtil {
+    public static String refineTime(LocalDateTime localDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return localDateTime.format(formatter);
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/util/TimeUtilCustom.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/util/TimeUtilCustom.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @RequiredArgsConstructor
-public class TimeUtil {
+public class TimeUtilCustom {
     public static String refineTime(LocalDateTime localDateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         return localDateTime.format(formatter);


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #24 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 게시물 좋아요 누른 것을 취소하는 API를 개발했습니다.
* 게시물에 좋아요를 누른 적이 없을 경우에 대해 예외 처리했습니다.
* 게시물 좋아요 취소와는 관계 없지만 createAt의 LocalDataTime형식을 클라 분들이 정제하시기 편하게 1차 정제하여 보내는 함수를 만들었습니다.
<img width="1268" alt="스크린샷 2024-01-12 오전 1 39 47" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/ff2b0571-35fd-4220-a61c-706e71ef6ecb">


<img width="1267" alt="스크린샷 2024-01-12 오전 1 39 37" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/58a6c4b2-6a1a-4ae8-923d-aa33bac327f6">

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
