### PR TITLE
[Feat] 답글 좋아요 취소 API 구현 #37

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.dontbe.www.DontBeServer.api.comment.controller;
 import com.dontbe.www.DontBeServer.api.comment.dto.request.CommentLikedRequestDto;
 import com.dontbe.www.DontBeServer.api.comment.dto.request.CommentPostRequestDto;
 import com.dontbe.www.DontBeServer.api.comment.service.CommentCommendService;
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.common.response.ApiResponse;
 import com.dontbe.www.DontBeServer.common.util.MemberUtil;
 import jakarta.validation.Valid;
@@ -35,5 +36,11 @@ public class CommentController {
         Long memberId = MemberUtil.getMemberId(principal);
         commentCommendService.likeComment(memberId, commentId, commentLikedRequestDto);
         return ApiResponse.success(COMMENT_LIKE_SUCCESS);
+    }
+    @DeleteMapping("comment/{commentId}/unliked")
+    public ResponseEntity<ApiResponse<Object>> unlikeComment(Principal principal,@PathVariable Long commentId) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        commentCommendService.unlikeComment(memberId, commentId);
+        return ApiResponse.success(COMMENT_UNLIKE_SUCCESS);
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/domain/CommentLiked.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/domain/CommentLiked.java
@@ -22,7 +22,7 @@ public class CommentLiked extends BaseTimeEntity {
     private Comment comment;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id") //
     private Member member;
 
     @Builder

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/domain/CommentLiked.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/domain/CommentLiked.java
@@ -22,7 +22,7 @@ public class CommentLiked extends BaseTimeEntity {
     private Comment comment;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id") //
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentLikedRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentLikedRepository.java
@@ -11,5 +11,5 @@ public interface CommentLikedRepository extends JpaRepository<CommentLiked, Long
 
     //int countByComment(Comment comment);
 
-    //void deleteByCommentAndMember(Comment comment, Member member);
+    void deleteByCommentAndMember(Comment comment, Member member);
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentCommendService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentCommendService.java
@@ -81,7 +81,7 @@ public class CommentCommendService {
                     .notificationTargetMember(targetMember)
                     .notificationTriggerMemberId(triggerMember.getId())
                     .notificationTriggerType(commentLikedRequestDto.notificationTriggerType())
-                    .notificationTriggerId(contentId)
+                    .notificationTriggerId(commentId)   //에러수정을 위한 notificationTriggerId에 답글id 저장, 알림 조회시 답글id로 게시글id 반환하도록하기
                     .isNotificationChecked(false)
                     .notificationText(comment.getCommentText())
                     .build();

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
@@ -38,6 +38,7 @@ public enum ErrorStatus {
     NOT_FOUND_MEMBER("해당하는 유저가 없습니다."),
     NOT_FOUND_CONTENT("해당하는 게시물이 없습니다."),
     NOT_FOUND_COMMENT("해당하는 답글이 없습니다."),
+    UNEXITST_COMENT_LIKE("좋아요를 누르지 않은 답글입니다."),
 
 
     /**

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum SuccessStatus {
-
     /**
      * auth
      */
@@ -32,7 +31,7 @@ public enum SuccessStatus {
     POST_COMMENT_SUCCESS(HttpStatus.CREATED,"답글 작성 성공"),
     DELETE_COMMENT_SUCCESS(HttpStatus.OK, "답글 삭제 성공"),
     COMMENT_LIKE_SUCCESS(HttpStatus.CREATED,"답글 좋아요 성공"),
-    COMMENT_UNLIKE_SUCCESS(HttpStatus.OK,"댓글 좋아요 취소 성공"),
+    COMMENT_UNLIKE_SUCCESS(HttpStatus.OK,"답글 좋아요 취소 성공"),
 
     /**
      * member


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #37 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 답글 좋아요 취소 API를 구현하였습니다

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 답글 좋아요시 notificationTriggerId에 게시물Id를 저장하기로 하여 좋아요 취소 시 한 게시물에 대한 한 유저의 모든 좋아요가 삭제되는 에러를 확인하여 notificationTriggerId에 답글 Id를 저장하는 것으로 수정하였습니다.
- 이 부분을 반영하여 알림 리스트 조회를 진행할 예정입니다. ( 알림 리스트 조회 진행 시 구현할 DTO단에서 답글 ID로 게시물Id를 반환할 예정입니다.
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/f5f7a462-d848-4bf2-bac1-c92c5041989c)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
