### PR TITLE
[FEAT]디비 스케쥴러 구현 완료

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/DontBeServerApplication.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/DontBeServerApplication.java
@@ -2,8 +2,10 @@ package com.dontbe.www.DontBeServer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DontBeServerApplication {
 
 	public static void main(String[] args) {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/ghost/domain/Ghost.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/ghost/domain/Ghost.java
@@ -1,6 +1,7 @@
 package com.dontbe.www.DontBeServer.api.ghost.domain;
 
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
+import com.dontbe.www.DontBeServer.common.entity.BaseDateEntity;
 import com.dontbe.www.DontBeServer.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -12,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Ghost extends BaseTimeEntity {
+public class Ghost extends BaseDateEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/ghost/repository/GhostDbRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/ghost/repository/GhostDbRepository.java
@@ -1,0 +1,29 @@
+package com.dontbe.www.DontBeServer.api.ghost.repository;
+
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+import com.dontbe.www.DontBeServer.api.ghost.domain.Ghost;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface GhostDbRepository extends CrudRepository<Ghost, Long> {
+
+    // 다른 메소드들은 유지한 채로 findGhostsToUpdate 메소드를 추가
+    @Query("SELECT g FROM Ghost g WHERE g.createdAt <= :fiveDaysAgo AND g.isRecovered = false")
+    List<Ghost> findGhostsToUpdate(@Param("fiveDaysAgo") LocalDate fiveDaysAgo);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Ghost g SET g.isRecovered = true WHERE g.createdAt <= :fiveDaysAgo AND g.isRecovered = false")
+    void updateGhostStatus(@Param("fiveDaysAgo") LocalDate fiveDaysAgo);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Member m SET m.memberGhost = m.memberGhost + 1 WHERE m = :member")
+    void incrementMemberGhostCount(@Param("member") Member member);
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/crontab/GhostScheduler.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/crontab/GhostScheduler.java
@@ -1,0 +1,33 @@
+package com.dontbe.www.DontBeServer.common.crontab;
+
+import com.dontbe.www.DontBeServer.api.ghost.domain.Ghost;
+import com.dontbe.www.DontBeServer.api.ghost.repository.GhostDbRepository;
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class GhostScheduler {
+
+    private final GhostDbRepository ghostDbRepository;
+
+    public GhostScheduler(GhostDbRepository ghostDbRepository) {
+        this.ghostDbRepository = ghostDbRepository;
+    }
+
+    @Scheduled(cron = "0 20 20 * * ?") // 매일 00:00에 실행
+    @Transactional
+    public void updateGhostStatus() {
+        LocalDate fiveDaysAgo = LocalDate.now().minusDays(5);
+        // 5일 전 이전에 생성된 Ghost 엔터티 중 isRecovered가 false인 것들을 찾아 업데이트
+        List<Ghost> ghostsToUpdate = ghostDbRepository.findGhostsToUpdate(fiveDaysAgo);
+        for (Ghost ghost : ghostsToUpdate) {
+            ghostDbRepository.updateGhostStatus(fiveDaysAgo);
+            ghostDbRepository.incrementMemberGhostCount(ghost.getGhostTargetMember());
+        }
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/entity/BaseDateEntity.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/entity/BaseDateEntity.java
@@ -1,0 +1,23 @@
+package com.dontbe.www.DontBeServer.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseDateEntity {
+
+    @CreatedDate
+    protected LocalDate createdAt;
+
+    @LastModifiedDate
+    protected LocalDate updatedAt;
+}
+


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #39 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 투명도가 5일 뒤에 회복되게끔 DB스케줄러를 구현했습니다.
* 그와 동시에 투명도가 낮춰졌던 유저의 전체 투명도도 1회복 될 수 있도록 했습니다.
* 아래 예시는 로직 상으로는 불가능한 케이스지만 더미 데이터를 넣어서 가능했었습니다. 로직에 문제 없게끔 수정해놓겠습니다.
<img width="1088" alt="스크린샷 2024-01-13 오후 8 26 09" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/33bb4fd9-68eb-4b41-b925-f7044f6e50df">
<img width="582" alt="스크린샷 2024-01-13 오후 8 26 36" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/0c4be713-3e0a-4e39-93a8-1008391d37fb">

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
