### PR TITLE
[FEAT]닉네임 중복 검사 API 개발

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
@@ -1,12 +1,14 @@
 package com.dontbe.www.DontBeServer.api.member.controller;
 
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberClickGhostRequestDto;
+import com.dontbe.www.DontBeServer.api.member.dto.request.MemberNicknameCheckRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberDetailGetResponseDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberGetProfileResponseDto;
 import com.dontbe.www.DontBeServer.api.member.service.MemberService;
 import com.dontbe.www.DontBeServer.common.response.ApiResponse;
 import com.dontbe.www.DontBeServer.common.util.MemberUtil;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -52,5 +54,11 @@ public class MemberController {
         Long memberId = MemberUtil.getMemberId(principal);
         memberService.updateMemberProfile(memberId, memberProfilePatchRequestDto);
         return ApiResponse.success(PATCH_MEMBER_PROFILE);
+    }
+
+    @GetMapping("nickname-validation")
+    public ResponseEntity<ApiResponse<Object>> checkMemberNickname(Principal principal, @Valid @RequestBody MemberNicknameCheckRequestDto memberNicknameCheckRequestDto) {
+        memberService.checkNicknameValidate(memberNicknameCheckRequestDto);
+        return ApiResponse.success(NICKNAME_CHECK_SUCCESS);
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/request/MemberNicknameCheckRequestDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/request/MemberNicknameCheckRequestDto.java
@@ -1,0 +1,8 @@
+package com.dontbe.www.DontBeServer.api.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberNicknameCheckRequestDto (
+        @NotBlank String nickname
+){
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/repository/MemberRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/repository/MemberRepository.java
@@ -19,4 +19,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByIdAndRefreshToken(Long memberId, String refreshToken);
 
     Optional<Member> findBySocialId(String socialId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/Impl/MemberServiceImpl.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/Impl/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import com.dontbe.www.DontBeServer.api.ghost.domain.Ghost;
 import com.dontbe.www.DontBeServer.api.ghost.repository.GhostRepository;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberClickGhostRequestDto;
+import com.dontbe.www.DontBeServer.api.member.dto.request.MemberNicknameCheckRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberDetailGetResponseDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberGetProfileResponseDto;
@@ -96,6 +97,12 @@ public class MemberServiceImpl implements MemberService {
 
         // 저장
         Member savedMember = memberRepository.save(existingMember);
+    }
+
+    public void checkNicknameValidate(MemberNicknameCheckRequestDto memberNicknameCheckRequestDto) {
+        if(memberRepository.existsByNickname(memberNicknameCheckRequestDto.nickname())){
+            throw new BadRequestException(ErrorStatus.NICKNAME_VALIDATE_ERROR.getMessage());
+        }
     }
 
     private void isDuplicateMemberGhost(Member triggerMember, Member targetMemmber) {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.dontbe.www.DontBeServer.api.member.service;
 
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberClickGhostRequestDto;
+import com.dontbe.www.DontBeServer.api.member.dto.request.MemberNicknameCheckRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberDetailGetResponseDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberGetProfileResponseDto;
@@ -16,4 +17,6 @@ public interface MemberService {
     void clickMemberGhost(Long memberId, MemberClickGhostRequestDto memberClickGhostRequestDto);
 
     void updateMemberProfile(Long memberId, MemberProfilePatchRequestDto memberProfilePatchRequestDto);
+
+    void checkNicknameValidate(MemberNicknameCheckRequestDto memberNicknameCheckRequestDto);
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus {
     DUPLICATION_COMMENT_LIKE("이미 좋아요를 누른 답글입니다."),
     UNEXITST_CONMMENT_LIKE("좋아요를 누르지 않은 답글입니다."),
     DUPLICATION_MEMBER_GHOST("이미 투명도를 누른 대상입니다."),
+    NICKNAME_VALIDATE_ERROR("이미 존재하는 닉네임입니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
@@ -40,7 +40,8 @@ public enum SuccessStatus {
     GET_MEMBER_DETAIL(HttpStatus.OK,"계정 정보 조회 성공"),
     GET_PROFILE_SUCCESS(HttpStatus.OK,"유저 프로필 조회 성공"),
     CLICK_MEMBER_GHOST_SUCCESS(HttpStatus.CREATED,"투명도 낮추기 성공"),
-    PATCH_MEMBER_PROFILE(HttpStatus.OK, "프로필 수정 완료")
+    PATCH_MEMBER_PROFILE(HttpStatus.OK, "프로필 수정 완료"),
+    NICKNAME_CHECK_SUCCESS(HttpStatus.OK, "사용 가능한 닉네임 입니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #46 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 닉네임 중복 검사를 하고 있을 경우 에러를 발생하는 API를 개발했습니다.
* 
<img width="970" alt="스크린샷 2024-01-14 오전 12 45 10" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/04df33d6-18fe-44d4-af19-e0fb8fbeba5a">
<img width="678" alt="스크린샷 2024-01-14 오전 12 45 26" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/687fc162-0b49-4154-972e-54b00d0f98d5">

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
