### PR TITLE
[FEAT]노티 읽음 처리 API개발 완료

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
@@ -1,0 +1,28 @@
+package com.dontbe.www.DontBeServer.api.notification.controller;
+
+import com.dontbe.www.DontBeServer.api.notification.service.NotificationCommandService;
+import com.dontbe.www.DontBeServer.common.response.ApiResponse;
+import com.dontbe.www.DontBeServer.common.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+import static com.dontbe.www.DontBeServer.common.response.SuccessStatus.*;
+
+@RestController
+@RequestMapping("/api/v1/")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationCommandService notificationCommandService;
+
+    @PostMapping("notification-check")
+    public ResponseEntity<ApiResponse<Object>> readNotification(Principal principal) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        notificationCommandService.readNotification(memberId);
+        return ApiResponse.success(READ_NOTIFICATION_SUCCESS);
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/domain/Notification.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/domain/Notification.java
@@ -40,4 +40,8 @@ public class Notification extends BaseTimeEntity{
         this.isNotificationChecked = isNotificationChecked;
         this.NotificationText = notificationText;
     }
+
+    public void readNotification(){
+        this.isNotificationChecked = true;
+    }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
@@ -4,8 +4,12 @@ import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     void deleteByNotificationTargetMemberAndNotificationTriggerMemberIdAndNotificationTriggerTypeAndNotificationTriggerId(
             Member notificaitonTargetMember, Long notificationTriggerMemberId, String notificationTriggerType, Long notificationTriggerId
     );
+
+    List<Notification> findAllByNotificationTargetMemberAndIsNotificationChecked(Member member, boolean b);
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationCommandService.java
@@ -1,0 +1,28 @@
+package com.dontbe.www.DontBeServer.api.notification.service;
+
+import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetAllByMemberResponseDto;
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
+import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
+import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
+import com.dontbe.www.DontBeServer.api.notification.repository.NotificationRepository;
+import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationCommandService {
+    private final MemberRepository memberRepository;
+    private final NotificationRepository notificationRepository;
+    @Transactional
+    public void readNotification(Long memberId) {
+        Member targetMember = memberRepository.findMemberByIdOrThrow(memberId);
+        List<Notification> unreadNotifications = notificationRepository.findAllByNotificationTargetMemberAndIsNotificationChecked(targetMember,false);
+
+        unreadNotifications.forEach(Notification::readNotification);
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
@@ -42,7 +42,11 @@ public enum SuccessStatus {
     GET_PROFILE_SUCCESS(HttpStatus.OK,"유저 프로필 조회 성공"),
     CLICK_MEMBER_GHOST_SUCCESS(HttpStatus.CREATED,"투명도 낮추기 성공"),
     PATCH_MEMBER_PROFILE(HttpStatus.OK, "프로필 수정 완료"),
-    NICKNAME_CHECK_SUCCESS(HttpStatus.OK, "사용 가능한 닉네임 입니다.")
+    NICKNAME_CHECK_SUCCESS(HttpStatus.OK, "사용 가능한 닉네임 입니다."),
+    /**
+     * member
+     */
+    READ_NOTIFICATION_SUCCESS(HttpStatus.CREATED,"노티 체크 성공")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #48 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 해당 유저의 알림들 중에 읽지 않은 알림들을 읽은 것으로 처리하는 API를 개발했습니다.
<img width="1124" alt="스크린샷 2024-01-14 오전 3 51 58" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/576f0d74-2e17-4daa-be54-798afe54c09c">
<img width="1233" alt="스크린샷 2024-01-14 오전 3 52 38" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/a404e973-f003-42a8-b10a-28e79fcb0177">

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
