### PR TITLE
[FEAT]안읽은 노티 개수 조회 API

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
@@ -1,10 +1,12 @@
 package com.dontbe.www.DontBeServer.api.notification.controller;
 
+import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificaitonCountResponseDto;
 import com.dontbe.www.DontBeServer.api.notification.service.NotificationCommandService;
 import com.dontbe.www.DontBeServer.common.response.ApiResponse;
 import com.dontbe.www.DontBeServer.common.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,5 +26,11 @@ public class NotificationController {
         Long memberId = MemberUtil.getMemberId(principal);
         notificationCommandService.readNotification(memberId);
         return ApiResponse.success(READ_NOTIFICATION_SUCCESS);
+    }
+
+    @GetMapping("notification/number")
+    public ResponseEntity<ApiResponse<NotificaitonCountResponseDto>> countNotification(Principal principal) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        return ApiResponse.success(COUNT_NOTIFICATION_SUCCESS, notificationCommandService.countUnreadNotification(memberId));
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.dontbe.www.DontBeServer.api.notification.controller;
 
 import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificaitonCountResponseDto;
 import com.dontbe.www.DontBeServer.api.notification.service.NotificationCommandService;
+import com.dontbe.www.DontBeServer.api.notification.service.NotificationQueryService;
 import com.dontbe.www.DontBeServer.common.response.ApiResponse;
 import com.dontbe.www.DontBeServer.common.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import static com.dontbe.www.DontBeServer.common.response.SuccessStatus.*;
 @RequiredArgsConstructor
 public class NotificationController {
     private final NotificationCommandService notificationCommandService;
+    private final NotificationQueryService notificationQueryService;
 
     @PostMapping("notification-check")
     public ResponseEntity<ApiResponse<Object>> readNotification(Principal principal) {
@@ -31,6 +33,6 @@ public class NotificationController {
     @GetMapping("notification/number")
     public ResponseEntity<ApiResponse<NotificaitonCountResponseDto>> countNotification(Principal principal) {
         Long memberId = MemberUtil.getMemberId(principal);
-        return ApiResponse.success(COUNT_NOTIFICATION_SUCCESS, notificationCommandService.countUnreadNotification(memberId));
+        return ApiResponse.success(COUNT_NOTIFICATION_SUCCESS, notificationQueryService.countUnreadNotification(memberId));
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificaitonCountResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificaitonCountResponseDto.java
@@ -1,0 +1,11 @@
+package com.dontbe.www.DontBeServer.api.notification.dto.response;
+
+public record NotificaitonCountResponseDto(
+        int notificationNumber
+) {
+    public static NotificaitonCountResponseDto of(int number) {
+        return new NotificaitonCountResponseDto(
+                number
+        );
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
@@ -12,4 +12,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     );
 
     List<Notification> findAllByNotificationTargetMemberAndIsNotificationChecked(Member member, boolean b);
+
+    int countByNotificationTargetMemberAndIsNotificationChecked(Member member, boolean b);
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationCommandService.java
@@ -1,20 +1,20 @@
 package com.dontbe.www.DontBeServer.api.notification.service;
 
-import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetAllByMemberResponseDto;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
 import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
+import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificaitonCountResponseDto;
 import com.dontbe.www.DontBeServer.api.notification.repository.NotificationRepository;
-import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class NotificationCommandService {
     private final MemberRepository memberRepository;
     private final NotificationRepository notificationRepository;
@@ -24,5 +24,11 @@ public class NotificationCommandService {
         List<Notification> unreadNotifications = notificationRepository.findAllByNotificationTargetMemberAndIsNotificationChecked(targetMember,false);
 
         unreadNotifications.forEach(Notification::readNotification);
+    }
+
+    public NotificaitonCountResponseDto countUnreadNotification(Long memberId) {
+        Member member = memberRepository.findMemberByIdOrThrow(memberId);
+        int number = notificationRepository.countByNotificationTargetMemberAndIsNotificationChecked(member, false);
+        return NotificaitonCountResponseDto.of(number);
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
@@ -2,26 +2,20 @@ package com.dontbe.www.DontBeServer.api.notification.service;
 
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
-import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
 import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificaitonCountResponseDto;
 import com.dontbe.www.DontBeServer.api.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class NotificationCommandService {
+public class NotificationQueryService {
     private final MemberRepository memberRepository;
     private final NotificationRepository notificationRepository;
-    @Transactional
-    public void readNotification(Long memberId) {
-        Member targetMember = memberRepository.findMemberByIdOrThrow(memberId);
-        List<Notification> unreadNotifications = notificationRepository.findAllByNotificationTargetMemberAndIsNotificationChecked(targetMember,false);
-
-        unreadNotifications.forEach(Notification::readNotification);
+    public NotificaitonCountResponseDto countUnreadNotification(Long memberId) {
+        Member member = memberRepository.findMemberByIdOrThrow(memberId);
+        int number = notificationRepository.countByNotificationTargetMemberAndIsNotificationChecked(member, false);
+        return NotificaitonCountResponseDto.of(number);
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
@@ -44,9 +44,10 @@ public enum SuccessStatus {
     PATCH_MEMBER_PROFILE(HttpStatus.OK, "프로필 수정 완료"),
     NICKNAME_CHECK_SUCCESS(HttpStatus.OK, "사용 가능한 닉네임 입니다."),
     /**
-     * member
+     * notification
      */
-    READ_NOTIFICATION_SUCCESS(HttpStatus.CREATED,"노티 체크 성공")
+    READ_NOTIFICATION_SUCCESS(HttpStatus.CREATED,"노티 체크 성공"),
+    COUNT_NOTIFICATION_SUCCESS(HttpStatus.OK,"노티 개수 체크 완료")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #50 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 유저의 안읽은 노티 개수를 반환하는 API입니다.
<img width="1291" alt="스크린샷 2024-01-14 오전 4 30 55" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/f9bc95f8-26fb-4257-a8f0-b19eb7a4c1a4">

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
