### PR TITLE
[FIX]소셜 로그인을 통해 가져오는 정보 수정 및 계정 정보 조회API수정

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/dto/SocialInfoDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/dto/SocialInfoDto.java
@@ -9,4 +9,5 @@ public class SocialInfoDto {
     private String id;
     private String nickname;
     private String profileUrl;
+    private String email;
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/service/Impl/AuthServiceImpl.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/service/Impl/AuthServiceImpl.java
@@ -27,6 +27,8 @@ import java.security.spec.InvalidKeySpecException;
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
+    private final static String GHOST_IMAGE = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
+
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoAuthService kakaoAuthService;
     private final MemberRepository memberRepository;
@@ -50,7 +52,8 @@ public class AuthServiceImpl implements AuthService {
                         .nickname(socialData.getNickname())
                         .socialPlatform(socialPlatform)
                         .socialId(socialData.getId())
-                        .profileUrl(socialData.getProfileUrl())
+                        .profileUrl(GHOST_IMAGE)
+                        .memberEmail(socialData.getEmail())
                         .build();
 
                 memberRepository.save(member);
@@ -60,7 +63,7 @@ public class AuthServiceImpl implements AuthService {
                 String accessToken = jwtTokenProvider.generateAccessToken(authentication);
                 member.updateRefreshToken(refreshToken);
 
-                return AuthResponseDto.of(member.getNickname(), member.getId(), accessToken, refreshToken, socialData.getProfileUrl(), true);
+                return AuthResponseDto.of(member.getNickname(), member.getId(), accessToken, refreshToken, member .getProfileUrl(), true);
 
             }
             else {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/service/KakaoAuthService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/service/KakaoAuthService.java
@@ -36,8 +36,9 @@ public class KakaoAuthService  {
             String nickname = jsonNode.get("kakao_account").get("profile").get("nickname").asText();
             String profileUrl = jsonNode.get("kakao_account").get("profile").get("profile_image_url").asText();
             String kakaoId = jsonNode.get("id").asText();
+            String email = jsonNode.get("kakao_account").get("email").asText();
 
-            return new SocialInfoDto(kakaoId, nickname, profileUrl);
+            return new SocialInfoDto(kakaoId, nickname, profileUrl,email);
         } catch (JsonProcessingException e) {
             throw new BaseException(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 계정 데이터 가공 실패");
         }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/domain/Member.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/domain/Member.java
@@ -50,6 +50,9 @@ public class Member extends BaseTimeEntity {
     @Column(name = "profile_url")
     private String profileUrl;
 
+    @Column(name = "member_email")
+    private String memberEmail;
+
     @OneToMany(mappedBy = "notificationTargetMember",cascade = ALL)
     private List<Notification> targetNotification = new ArrayList<>();
 
@@ -63,13 +66,14 @@ public class Member extends BaseTimeEntity {
     private List<Report> targetReport = new ArrayList<>();
 
     @Builder
-    private Member(String nickname, SocialPlatform socialPlatform, String socialId,String profileUrl) {
+    private Member(String nickname, SocialPlatform socialPlatform, String socialId, String profileUrl, String memberEmail) {
         this.nickname = nickname;
         this.socialId = socialId;
         this.socialPlatform = socialPlatform;
         this.profileUrl = profileUrl;
         this.memberIntro = "";
         this.memberGhost = 0;
+        this.memberEmail = memberEmail;
     }
 
     public void decreaseGhost() {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/response/MemberDetailGetResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/response/MemberDetailGetResponseDto.java
@@ -13,7 +13,7 @@ public record MemberDetailGetResponseDto(
         return new MemberDetailGetResponseDto(
                 member.getId(),
                 joinDate,
-                member.getSocialId(),
+                member.getMemberEmail(),
                 member.getSocialPlatform().name() + " SOCIAL LOGIN",
                 "1.0.01"
         );


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #56 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 소셜 로그인을 통해서 카카오 계정 이메일을 가져와 저장하게 했습니다.
* 유저들의 이미지를 기본 이미지로 고정했습니다.
* 계정 정보 조회 API에서 socialId값이 아닌 kakao 이메일 계정이 반환되도록 수정했습니다.
<img width="801" alt="스크린샷 2024-01-14 오후 8 07 23" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/7240daed-d73e-4eb3-9343-760de19bfe9b">
<img width="1202" alt="스크린샷 2024-01-14 오후 8 07 51" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/21400ad3-dd51-4be5-9a72-71f761762038">

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
