### PR TITLE
멤버에 해당하는 답글 리스트 조회 API 구현/#53

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
@@ -48,5 +48,9 @@ public class CommentController {
         Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponse.success(GET_COMMENT_ALL_SUCCESS, commentQueryService.getCommentAll(memberId, contentId));
     }
-
+    @GetMapping("member/{memberId}/comments")
+    public ResponseEntity<ApiResponse<Object>> getMemberComment(Principal principal, @PathVariable Long memberId){
+        Long usingMemberId = MemberUtil.getMemberId(principal);
+        return ApiResponse.success(GET_MEMBER_COMMENT_SECCESS, commentQueryService.getMemberComment(usingMemberId,memberId));
+    }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/request/CommentPostRequestDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/request/CommentPostRequestDto.java
@@ -2,7 +2,6 @@ package com.dontbe.www.DontBeServer.api.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-
 public record CommentPostRequestDto(
         @NotBlank String commentText
 ) {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllByMemberResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllByMemberResponseDto.java
@@ -1,0 +1,36 @@
+package com.dontbe.www.DontBeServer.api.comment.dto.response;
+
+import com.dontbe.www.DontBeServer.api.comment.domain.Comment;
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
+import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
+
+public record CommentAllByMemberResponseDto(
+        long memberId,	//	답글 작성자 Id
+        String memberProfileUrl, //	작성자 프로필 사진url
+        String memberNickname,   //	답글 작성자 닉네임
+        Boolean isLiked,	//	유저가 답글에 대해 좋아요를 눌렀는지
+        Boolean isGhost, //답글 작성자를 투명도 처리 했는지
+        int memberGhost,  //	답글 작성자의 전체 투명도
+        int commentLikedNumber,  //	답글 좋아요 개수
+        String commentText,  //	답글 내용
+        String time, //답글이 작성된 시간 (년-월-일 시:분:초)
+        long    commentId,    //댓글 Id
+        long contentId //	해당 댓글이 적힌 게시물 Id
+) {
+    public static CommentAllByMemberResponseDto of(Member writerMember, boolean isLiked, boolean isGhost,
+    int memberGhost, int commentLikedNumber, Comment comment){
+        return new CommentAllByMemberResponseDto(
+                writerMember.getId() ,
+                writerMember.getProfileUrl(),
+                writerMember.getNickname(),
+                isLiked,
+                isGhost,
+                memberGhost,
+                commentLikedNumber,
+                comment.getCommentText(),
+                TimeUtilCustom.refineTime(comment.getCreatedAt()),
+                comment.getId(),
+                comment.getContent().getId()
+        );
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
@@ -6,6 +6,7 @@ import com.dontbe.www.DontBeServer.common.exception.NotFoundException;
 import com.dontbe.www.DontBeServer.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -13,7 +14,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findCommentById(Long commentId);
 
-    Comment findCommentByContentId(Long contentId);
+    //Comment findCommentByContentId(Long contentId);
+
+    List<Comment> findCommentsByMemberId(Long memberId);
 
     default Comment findCommentByIdOrThrow(Long commentId) {
         return findCommentById(commentId)

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
@@ -14,7 +14,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findCommentById(Long commentId);
 
-    //Comment findCommentByContentId(Long contentId);
+    List<Comment> findCommentsByContentId(Long contentId);
 
     List<Comment> findCommentsByMemberId(Long memberId);
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentCommendService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentCommendService.java
@@ -39,7 +39,6 @@ public class CommentCommendService {
                 .content(content)
                 .commentText(commentPostRequestDto.commentText())
                 .build();
-
         Comment savedComment = commentRepository.save(comment);
     }
 
@@ -105,9 +104,6 @@ public class CommentCommendService {
         }else{ //댓글좋아요 엔티티에 존재하지 않을 경우 예외처리
             throw new BadRequestException(ErrorStatus.UNEXITST_COMENT_LIKE.getMessage());
         }
-        //게시물 작성자 = target,
-
-
     }
 
     private void isDuplicateCommentLike(Comment comment, Member member) {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
@@ -5,7 +5,6 @@ import com.dontbe.www.DontBeServer.api.comment.dto.response.CommentAllByMemberRe
 import com.dontbe.www.DontBeServer.api.comment.dto.response.CommentAllResponseDto;
 import com.dontbe.www.DontBeServer.api.comment.repository.CommentLikedRepository;
 import com.dontbe.www.DontBeServer.api.comment.repository.CommentRepository;
-import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
 import com.dontbe.www.DontBeServer.api.ghost.repository.GhostRepository;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
@@ -14,8 +13,6 @@ import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,10 +24,9 @@ public class CommentQueryService {
     private final CommentRepository commentRepository;
     private final GhostRepository ghostRepository;
     private final CommentLikedRepository commentLikedRepository;
-    private final ContentRepository contentRepository;
 
     public List<CommentAllResponseDto> getCommentAll(Long memberId, Long contentId) {
-        List<Comment> commentList = commentRepository.findAll();
+        List<Comment> commentList = commentRepository.findCommentsByContentId(contentId);
 
         return commentList.stream()
                 .map( oneComment -> CommentAllResponseDto.of(
@@ -59,7 +55,6 @@ public class CommentQueryService {
     }
 
     private boolean checkGhost(Long usingMemberId, Long commentId){
-        Member member = memberRepository.findMemberByIdOrThrow(usingMemberId);
         Member writerMember = commentRepository.findCommentByIdOrThrow(commentId).getMember();
         return ghostRepository.existsByGhostTargetMemberIdAndGhostTriggerMemberId(usingMemberId, writerMember.getId());
     }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
@@ -1,6 +1,7 @@
 package com.dontbe.www.DontBeServer.api.comment.service;
 
 import com.dontbe.www.DontBeServer.api.comment.domain.Comment;
+import com.dontbe.www.DontBeServer.api.comment.dto.response.CommentAllByMemberResponseDto;
 import com.dontbe.www.DontBeServer.api.comment.dto.response.CommentAllResponseDto;
 import com.dontbe.www.DontBeServer.api.comment.repository.CommentLikedRepository;
 import com.dontbe.www.DontBeServer.api.comment.repository.CommentRepository;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,31 +30,34 @@ public class CommentQueryService {
     private final ContentRepository contentRepository;
 
     public List<CommentAllResponseDto> getCommentAll(Long memberId, Long contentId) {
-//        Member principal = ;
-//        Comment comment = commentRepository.findCommentByContentId(contentId);
-//        Member writerMember = comment.getMember();
-//        int writerMemberGhost = GhostUtil.refineGhost(writerMember.getMemberGhost());
-//        boolean isGhost = ghostRepository.existsByGhostTargetMemberIdAndGhostTriggerMemberId(memberId, writerMember.getId());
-//        boolean isLiked = commentLikedRepository.existsByCommentAndMember(comment,principal);
-//        String time = TimeUtilCustom.refineTime(comment.getCreatedAt());
-//        int likedNumber = commentLikedRepository.countByComment(comment);
-        //oneComment.getMember()
-          List<Comment> commentList = commentRepository.findAll();
-        // int likedNumber = likedNumber(contentId);
+        List<Comment> commentList = commentRepository.findAll();
 
         return commentList.stream()
                 .map( oneComment -> CommentAllResponseDto.of(
                         memberRepository.findMemberByIdOrThrow(memberId),
                         checkGhost(memberId, oneComment.getId()),
-                        checkMemberGhost(contentId),
+                        checkMemberGhost(oneComment.getId()),
                         checkLikedComment(memberId,oneComment.getId()),
                         TimeUtilCustom.refineTime(oneComment.getCreatedAt()),
                         likedNumber(contentId),
                         oneComment.getCommentText()))
                 .collect(Collectors.toList());
-
-
     }
+
+    public List<CommentAllByMemberResponseDto> getMemberComment(Long principalId, Long memberId){
+        List<Comment> commentList = commentRepository.findCommentsByMemberId(memberId);
+
+        return commentList.stream()
+                .map( oneComment -> CommentAllByMemberResponseDto.of(
+                    memberRepository.findMemberByIdOrThrow(memberId),
+                        checkLikedComment(principalId, oneComment.getId()),
+                        checkGhost(principalId, oneComment.getId()),
+                        checkMemberGhost(oneComment.getId()),
+                        likedNumber(oneComment.getId()),
+                        oneComment)
+                ).collect(Collectors.toList());
+    }
+
     private boolean checkGhost(Long usingMemberId, Long commentId){
         Member member = memberRepository.findMemberByIdOrThrow(usingMemberId);
         Member writerMember = commentRepository.findCommentByIdOrThrow(commentId).getMember();
@@ -63,8 +68,9 @@ public class CommentQueryService {
         Comment comment = commentRepository.findCommentByIdOrThrow(commentId);
         return commentLikedRepository.existsByCommentAndMember(comment,member);
     }
-    private int checkMemberGhost(Long contentId){
-        Member member = contentRepository.findContentByIdOrThrow(contentId).getMember();
+    private int checkMemberGhost(Long commentId){
+        Member member = commentRepository.findCommentByIdOrThrow(commentId).getMember();
+        //contentRepository.findContentByIdOrThrow(commentId).getMember();
         return GhostUtil.refineGhost(member.getMemberGhost());
     }
     private int likedNumber(Long commentId){

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
@@ -35,6 +35,7 @@ public enum SuccessStatus {
     COMMENT_LIKE_SUCCESS(HttpStatus.CREATED,"답글 좋아요 성공"),
     COMMENT_UNLIKE_SUCCESS(HttpStatus.OK,"답글 좋아요 취소 성공"),
     GET_COMMENT_ALL_SUCCESS(HttpStatus.OK,"게시물에 해당하는 답글 리스트 조회 성공"),
+    GET_MEMBER_COMMENT_SECCESS(HttpStatus.OK,"멤버에 해당하는 답글 리스트 조회 성공"),
 
     /**
      * member


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #53 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
멤버에 해당하는 답글 리스트 조회하는 API를 구현하였습니다.
게시물에 해당하는 답글 리스트 조회 시 모든 답글이 조회되는 에러를 수정했습니다.
해당 API를 구현하며 겪었던 에러와 동일하여 같은 이슈로 한번에 PR 보내요!

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/d40fa525-0fa9-4461-b29b-23f82aa607e7)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
