### PR TITLE
[FEAT] 멤버에 해당하는 노티 리스트 조회 API 구현 완료 #59

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.dontbe.www.DontBeServer.api.comment.repository;
 
 import com.dontbe.www.DontBeServer.api.comment.domain.Comment;
 import com.dontbe.www.DontBeServer.api.content.domain.Content;
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.common.exception.NotFoundException;
 import com.dontbe.www.DontBeServer.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,7 +14,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findCommentById(Long commentId);
 
-    Comment findCommentByContentId(Long contentId);
+    Comment findCommentByMember(Member member);
 
     default Comment findCommentByIdOrThrow(Long commentId) {
         return findCommentById(commentId)

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
@@ -33,9 +33,9 @@ public class NotificationController {
         return ApiResponse.success(COUNT_NOTIFICATION_SUCCESS, notificationQueryService.countUnreadNotification(memberId));
     }
 
-    @GetMapping("member/{targetMemberId}/notification")
-    public ResponseEntity<ApiResponse<Object>> getNotification(Principal principal, @PathVariable Long targetMemberId) {
+    @GetMapping("/notification-all")
+    public ResponseEntity<ApiResponse<Object>> getNotification(Principal principal) {
         Long memberId = MemberUtil.getMemberId(principal);
-        return ApiResponse.success(NOTIFICATION_ALL_SUCCESS, notificationQueryService.getNotificationAll(memberId, targetMemberId));
+        return ApiResponse.success(NOTIFICATION_ALL_SUCCESS, notificationQueryService.getNotificationAll(memberId));
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/controller/NotificationController.java
@@ -7,10 +7,7 @@ import com.dontbe.www.DontBeServer.common.response.ApiResponse;
 import com.dontbe.www.DontBeServer.common.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
@@ -34,5 +31,11 @@ public class NotificationController {
     public ResponseEntity<ApiResponse<NotificaitonCountResponseDto>> countNotification(Principal principal) {
         Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponse.success(COUNT_NOTIFICATION_SUCCESS, notificationQueryService.countUnreadNotification(memberId));
+    }
+
+    @GetMapping("member/{targetMemberId}/notification")
+    public ResponseEntity<ApiResponse<Object>> getNotification(Principal principal, @PathVariable Long targetMemberId) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        return ApiResponse.success(NOTIFICATION_ALL_SUCCESS, notificationQueryService.getNotificationAll(memberId, targetMemberId));
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
@@ -1,0 +1,33 @@
+package com.dontbe.www.DontBeServer.api.notification.dto.response;
+
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
+import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
+import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
+
+public record NotificationAllResponseDto(
+        long memberId,   //사용하는 유저Id
+        String memberNickname,  //사용하는 유저 닉네임
+        String triggerMemberNickname,	//노티 유발자의 닉네임
+        String triggerMemberProfileUrl,	//노티 유발자 프로필 사진url
+        String notificationTriggerType,
+        String time,	//	노티가 발생한 시간을 (년-월-일 시:분:초)
+        Long notificationIriggerId ,    //	노티 발생 시 해당 경우의 Id
+        String notificationText, //	댓글 노티에 나올 댓글 내용
+        boolean isNotificationChecked    //	유저가 확인한 노티인지 아닌지
+) {
+    public static NotificationAllResponseDto of(Member usingMember, Member triggerMember, Notification notification, boolean isNotificationChecked) {
+        return new NotificationAllResponseDto(
+                usingMember.getId(),
+                usingMember.getNickname(),
+                triggerMember.getNickname(),
+                triggerMember.getProfileUrl(),
+                notification.getNotificationTriggerType(),
+                TimeUtilCustom.refineTime(notification.getCreatedAt()),
+                notification.getId(),
+                notification.getNotificationText(),
+                isNotificationChecked
+        );
+    }
+
+}
+

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
@@ -15,12 +15,13 @@ public record NotificationAllResponseDto(
         String notificationText, //	댓글 노티에 나올 댓글 내용
         boolean isNotificationChecked    //	유저가 확인한 노티인지 아닌지
 ) {
-    public static NotificationAllResponseDto of(Member usingMember, Member triggerMember, Notification notification, boolean isNotificationChecked, Long notificationTriggerId) {
+    public static NotificationAllResponseDto of(Member usingMember, Member triggerMember, Notification notification,
+                                                boolean isNotificationChecked, Long notificationTriggerId, String imageUrl) {
         return new NotificationAllResponseDto(
                 usingMember.getId(),
                 usingMember.getNickname(),
                 triggerMember.getNickname(),
-                triggerMember.getProfileUrl(),
+                imageUrl,
                 notification.getNotificationTriggerType(),
                 TimeUtilCustom.refineTime(notification.getCreatedAt()),
                 notificationTriggerId,

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
@@ -11,11 +11,11 @@ public record NotificationAllResponseDto(
         String triggerMemberProfileUrl,	//노티 유발자 프로필 사진url
         String notificationTriggerType,
         String time,	//	노티가 발생한 시간을 (년-월-일 시:분:초)
-        Long notificationIriggerId ,    //	노티 발생 시 해당 경우의 Id
+        Long notificationTriggerId ,    //	노티 발생 시 해당 경우의 Id
         String notificationText, //	댓글 노티에 나올 댓글 내용
         boolean isNotificationChecked    //	유저가 확인한 노티인지 아닌지
 ) {
-    public static NotificationAllResponseDto of(Member usingMember, Member triggerMember, Notification notification, boolean isNotificationChecked) {
+    public static NotificationAllResponseDto of(Member usingMember, Member triggerMember, Notification notification, boolean isNotificationChecked, Long notificationTriggerId) {
         return new NotificationAllResponseDto(
                 usingMember.getId(),
                 usingMember.getNickname(),
@@ -23,7 +23,7 @@ public record NotificationAllResponseDto(
                 triggerMember.getProfileUrl(),
                 notification.getNotificationTriggerType(),
                 TimeUtilCustom.refineTime(notification.getCreatedAt()),
-                notification.getId(),
+                notificationTriggerId,
                 notification.getNotificationText(),
                 isNotificationChecked
         );

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
@@ -14,4 +14,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findAllByNotificationTargetMemberAndIsNotificationChecked(Member member, boolean b);
 
     int countByNotificationTargetMemberAndIsNotificationChecked(Member member, boolean b);
+
+    List<Notification> findNotificationsByNotificationTargetMember(Member member);
+
+    //boolean findIsNotificationCheckedById(Long notificationId);
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/repository/NotificationRepository.java
@@ -17,5 +17,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findNotificationsByNotificationTargetMember(Member member);
 
-    //boolean findIsNotificationCheckedById(Long notificationId);
+    Notification findNotificationById(Long notificationId);
+
+//    default Notification findNotificationByIdOrThrow(Long notificationId) {
+//        return findNotificationByIdOrThrow(notificationId)
+//        orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_NOTIFICATION.getMessage()));
+//    }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
@@ -21,6 +21,7 @@ public class NotificationQueryService {
     private final MemberRepository memberRepository;
     private final NotificationRepository notificationRepository;
     private final CommentRepository commentRepository;
+    private final String SYSTEM_PROFILEURL = "https://github.com/TeamDon-tBe/SERVER/assets/128011308/327d416e-ef1f-4c10-961d-4d9b85632d87";
 
     public NotificaitonCountResponseDto countUnreadNotification(Long memberId) {
         Member member = memberRepository.findMemberByIdOrThrow(memberId);
@@ -28,11 +29,10 @@ public class NotificationQueryService {
         return NotificaitonCountResponseDto.of(number);
     }
 
-    public List<NotificationAllResponseDto> getNotificationAll(Long memberId, Long targetMemberId){
+    public List<NotificationAllResponseDto> getNotificationAll(Long memberId){
         Member usingMember = memberRepository.findMemberByIdOrThrow(memberId);
-        Member targetMember = memberRepository.findMemberByIdOrThrow(targetMemberId);
-        List<Notification> notificationList = notificationRepository.findNotificationsByNotificationTargetMember(targetMember);
-
+        System.out.println("1");
+        List<Notification> notificationList = notificationRepository.findNotificationsByNotificationTargetMember(usingMember);
 
         return notificationList.stream()
                 .map(oneNotification -> NotificationAllResponseDto.of(
@@ -41,17 +41,32 @@ public class NotificationQueryService {
                         oneNotification,
                         oneNotification.isNotificationChecked(),
                         notificationTriggerId(oneNotification.getNotificationTriggerType(),
-                                oneNotification.getNotificationTriggerId(), oneNotification )
+                                oneNotification.getNotificationTriggerId(), oneNotification),
+                        profileUrl(oneNotification.getId(), oneNotification.getNotificationTriggerType())
                 )).collect(Collectors.toList());
     }
 
     private long notificationTriggerId (String triggerType, Long triggerId, Notification notification){
 
         Comment comment = commentRepository.findCommentByIdOrThrow(triggerId);
-
+        System.out.println("2");
         //답글관련(답글좋아요 혹은 답글 작성)시 게시물 id 반환
         if(triggerType.equals("comment") || triggerType.equals("commentLiked")){
+            System.out.println("3");
             return comment.getContent().getId();
-        }else {return notification.getNotificationTriggerId();}
+        }else {
+            System.out.println("4");
+            return notification.getNotificationTriggerId();}
+    }
+
+    private String profileUrl(Long notificationId, String triggerType){
+        Notification notification = notificationRepository.findNotificationById(notificationId);
+        Member triggerMember = memberRepository.findMemberByIdOrThrow(notification.getNotificationTriggerMemberId());
+        System.out.println("5");
+        if(triggerType.equals("comment") || triggerType.equals("commentLiked") || triggerType.equals("contentLiked")){
+            return triggerMember.getProfileUrl();
+        }else{
+            return SYSTEM_PROFILEURL;
+        }
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
@@ -1,5 +1,7 @@
 package com.dontbe.www.DontBeServer.api.notification.service;
 
+import com.dontbe.www.DontBeServer.api.comment.domain.Comment;
+import com.dontbe.www.DontBeServer.api.comment.repository.CommentRepository;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
 import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
@@ -18,6 +20,7 @@ import java.util.stream.Collectors;
 public class NotificationQueryService {
     private final MemberRepository memberRepository;
     private final NotificationRepository notificationRepository;
+    private final CommentRepository commentRepository;
 
     public NotificaitonCountResponseDto countUnreadNotification(Long memberId) {
         Member member = memberRepository.findMemberByIdOrThrow(memberId);
@@ -30,15 +33,27 @@ public class NotificationQueryService {
         Member targetMember = memberRepository.findMemberByIdOrThrow(targetMemberId);
         List<Notification> notificationList = notificationRepository.findNotificationsByNotificationTargetMember(targetMember);
 
-        //System.out.println("usingMemberId : "+ usingMember.getId().toString());
 
-        //댓글알림이면 triggerId > contentId반환추가하기
         return notificationList.stream()
                 .map(oneNotification -> NotificationAllResponseDto.of(
                         usingMember,
                         memberRepository.findMemberByIdOrThrow(oneNotification.getNotificationTriggerMemberId()),
                         oneNotification,
-                        oneNotification.isNotificationChecked()
+                        oneNotification.isNotificationChecked(),
+                        notificationTriggerId(oneNotification.getNotificationTriggerType(),
+                                oneNotification.getNotificationTargetMember(), oneNotification )
                 )).collect(Collectors.toList());
+    }
+
+    private long notificationTriggerId (String triggerType, Member targetMember , Notification notification){
+
+        List<Comment> commentList = commentRepository.findCommentByMember(targetMember);
+        return notificationList.stream()
+                .map(oneCommet->  )
+
+        //답글관련(답글좋아요 혹은 답글 작성)시 게시물 id 반환
+        if(triggerType.equals("comment") || triggerType.equals("commentLiked")){
+            return comment.getContent().getId();
+        }else {return notification.getNotificationTriggerId();}
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
@@ -41,15 +41,13 @@ public class NotificationQueryService {
                         oneNotification,
                         oneNotification.isNotificationChecked(),
                         notificationTriggerId(oneNotification.getNotificationTriggerType(),
-                                oneNotification.getNotificationTargetMember(), oneNotification )
+                                oneNotification.getNotificationTriggerId(), oneNotification )
                 )).collect(Collectors.toList());
     }
 
-    private long notificationTriggerId (String triggerType, Member targetMember , Notification notification){
+    private long notificationTriggerId (String triggerType, Long triggerId, Notification notification){
 
-        List<Comment> commentList = commentRepository.findCommentByMember(targetMember);
-        return notificationList.stream()
-                .map(oneCommet->  )
+        Comment comment = commentRepository.findCommentByIdOrThrow(triggerId);
 
         //답글관련(답글좋아요 혹은 답글 작성)시 게시물 id 반환
         if(triggerType.equals("comment") || triggerType.equals("commentLiked")){

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
@@ -2,10 +2,15 @@ package com.dontbe.www.DontBeServer.api.notification.service;
 
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
+import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
 import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificaitonCountResponseDto;
+import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificationAllResponseDto;
 import com.dontbe.www.DontBeServer.api.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -13,9 +18,27 @@ import org.springframework.stereotype.Service;
 public class NotificationQueryService {
     private final MemberRepository memberRepository;
     private final NotificationRepository notificationRepository;
+
     public NotificaitonCountResponseDto countUnreadNotification(Long memberId) {
         Member member = memberRepository.findMemberByIdOrThrow(memberId);
         int number = notificationRepository.countByNotificationTargetMemberAndIsNotificationChecked(member, false);
         return NotificaitonCountResponseDto.of(number);
+    }
+
+    public List<NotificationAllResponseDto> getNotificationAll(Long memberId, Long targetMemberId){
+        Member usingMember = memberRepository.findMemberByIdOrThrow(memberId);
+        Member targetMember = memberRepository.findMemberByIdOrThrow(targetMemberId);
+        List<Notification> notificationList = notificationRepository.findNotificationsByNotificationTargetMember(targetMember);
+
+        //System.out.println("usingMemberId : "+ usingMember.getId().toString());
+
+        //댓글알림이면 triggerId > contentId반환추가하기
+        return notificationList.stream()
+                .map(oneNotification -> NotificationAllResponseDto.of(
+                        usingMember,
+                        memberRepository.findMemberByIdOrThrow(oneNotification.getNotificationTriggerMemberId()),
+                        oneNotification,
+                        oneNotification.isNotificationChecked()
+                )).collect(Collectors.toList());
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/SuccessStatus.java
@@ -44,6 +44,7 @@ public enum SuccessStatus {
     CLICK_MEMBER_GHOST_SUCCESS(HttpStatus.CREATED,"투명도 낮추기 성공"),
     PATCH_MEMBER_PROFILE(HttpStatus.OK, "프로필 수정 완료"),
     NICKNAME_CHECK_SUCCESS(HttpStatus.OK, "사용 가능한 닉네임 입니다."),
+    NOTIFICATION_ALL_SUCCESS(HttpStatus.OK,"알림 전체 조회 성공"),
     /**
      * notification
      */


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #59 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
유저에 해당하는 알림 리스트를 조회하는 API를 구현했습니다.
답글 관련 알림 발생 시 게시물로 이동하도록 하기 위해서 DTO에 게시물 id를 반환하도록 하였습니다.
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/75c83501-4f7a-4d8c-a307-2fdb5a4003a4)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
