### PR TITLE
게시물에 해당하는 답글 리스트 조회 API 페이지네이션 구현 /#70

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
@@ -43,10 +43,10 @@ public class CommentController {
         commentCommendService.unlikeComment(memberId, commentId);
         return ApiResponse.success(COMMENT_UNLIKE_SUCCESS);
     }
-    @GetMapping("content/{contentId}/comment/all")
-    public ResponseEntity<ApiResponse<Object>> getCommentAll(Principal principal, @PathVariable Long contentId){
+    @GetMapping("content/{contentId}/comment")
+    public ResponseEntity<ApiResponse<Object>> getCommentAll(Principal principal, @PathVariable Long contentId, @RequestParam(value = "cursor") int cursor){    //cursor= last commentId
         Long memberId = MemberUtil.getMemberId(principal);
-        return ApiResponse.success(GET_COMMENT_ALL_SUCCESS, commentQueryService.getCommentAll(memberId, contentId));
+        return ApiResponse.success(GET_COMMENT_ALL_SUCCESS, commentQueryService.getCommentAll(memberId, contentId, cursor));
     }
     @GetMapping("member/{memberId}/comments")
     public ResponseEntity<ApiResponse<Object>> getMemberComment(Principal principal, @PathVariable Long memberId){

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
@@ -43,8 +43,8 @@ public class CommentController {
         commentCommendService.unlikeComment(memberId, commentId);
         return ApiResponse.success(COMMENT_UNLIKE_SUCCESS);
     }
-    @GetMapping("content/{contentId}/comment")
-    public ResponseEntity<ApiResponse<Object>> getCommentAll(Principal principal, @PathVariable Long contentId, @RequestParam(value = "cursor") int cursor){    //cursor= last commentId
+    @GetMapping("content/{contentId}/comments")
+    public ResponseEntity<ApiResponse<Object>> getCommentAll(Principal principal, @PathVariable Long contentId, @RequestParam(value = "cursor") Long cursor){    //cursor= last commentId
         Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponse.success(GET_COMMENT_ALL_SUCCESS, commentQueryService.getCommentAll(memberId, contentId, cursor));
     }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
@@ -5,9 +5,12 @@ import com.dontbe.www.DontBeServer.api.content.domain.Content;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.common.exception.NotFoundException;
 import com.dontbe.www.DontBeServer.common.response.ErrorStatus;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,7 +22,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Comment findCommentByMember(Member member);
 
-    Slice<Comment> findCommentsByContentIdOrderByCreatedAtAsc(Long contentId, Pageable pageable);
+    @Query("SELECT c FROM Comment c WHERE c.id <= ?1 AND c.content.id = ?2 ORDER BY c.createdAt DESC")
+    Slice<Comment> findNextPage(Long lastCommentId, Long contentId, PageRequest pageRequest);
+
+    //Slice<Comment> findTopById(int lastCommentId, Long contentId, PageRequest pageRequest);
+
+    Slice<Comment> findCommentsTopByContentIdOrderByCreatedAtDesc(Long contentId, PageRequest pageRequest);
 
     List<Comment> findCommentsByMemberIdOrderByCreatedAtAsc(Long memberId);
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
@@ -5,6 +5,8 @@ import com.dontbe.www.DontBeServer.api.content.domain.Content;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.common.exception.NotFoundException;
 import com.dontbe.www.DontBeServer.common.response.ErrorStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -17,7 +19,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Comment findCommentByMember(Member member);
 
-    List<Comment> findCommentsByContentIdOrderByCreatedAtAsc(Long contentId);
+    Slice<Comment> findCommentsByContentIdOrderByCreatedAtAsc(Long contentId, Pageable pageable);
 
     List<Comment> findCommentsByMemberIdOrderByCreatedAtAsc(Long memberId);
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
@@ -13,7 +13,6 @@ import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,14 +28,14 @@ public class CommentQueryService {
     private final GhostRepository ghostRepository;
     private final CommentLikedRepository commentLikedRepository;
 
-    private final int DEFAULT_PAGE_SIZE = 5;
+    private final int DEFAULT_PAGE_SIZE = 20;
 
 
     public List<CommentAllResponseDto> getCommentAll(Long memberId, Long contentId, Long cursor) {
         PageRequest pageRequest = PageRequest.of(0, DEFAULT_PAGE_SIZE);
         Slice<Comment> commentList;
 
-        if (cursor==0) {
+        if (cursor==-1) {
              commentList = commentRepository.findCommentsTopByContentIdOrderByCreatedAtDesc(contentId, pageRequest);
 
         } else {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
@@ -11,6 +11,9 @@ import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
 import com.dontbe.www.DontBeServer.common.util.GhostUtil;
 import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -25,8 +28,12 @@ public class CommentQueryService {
     private final GhostRepository ghostRepository;
     private final CommentLikedRepository commentLikedRepository;
 
-    public List<CommentAllResponseDto> getCommentAll(Long memberId, Long contentId) {
-        List<Comment> commentList = commentRepository.findCommentsByContentIdOrderByCreatedAtAsc(contentId);
+    private final int DEFAULT_PAGE_SIZE = 20;
+
+
+    public List<CommentAllResponseDto> getCommentAll( Long memberId, Long contentId, int cursor) {
+        PageRequest pageRequest = PageRequest.of(cursor,DEFAULT_PAGE_SIZE);
+        Slice<Comment> commentList = commentRepository.findCommentsByContentIdOrderByCreatedAtAsc(contentId, pageRequest);
 
         return commentList.stream()
                 .map( oneComment -> CommentAllResponseDto.of(


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #70 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
커서기반 페이지네이션 구현했습니다.
첫 조회시 제일 나중에 작성된 답글이 조회되도록(findCommentsTop)을 사용하였습니다.
한번 호출 시 20개의 답글이 조회됩니다
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/0df7e2c4-c2f8-4cb5-9cba-b1d9c99e8b13)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
