### PR TITLE
[ADD] 커서기반 pagination 적용 - 유저에 해당하는 답글 리스트 조회 API #77

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/controller/CommentController.java
@@ -43,14 +43,14 @@ public class CommentController {
         commentCommendService.unlikeComment(memberId, commentId);
         return ApiResponse.success(COMMENT_UNLIKE_SUCCESS);
     }
-    @GetMapping("content/{contentId}/comment/all")
-    public ResponseEntity<ApiResponse<Object>> getCommentAll(Principal principal, @PathVariable Long contentId){
+    @GetMapping("content/{contentId}/comments")
+    public ResponseEntity<ApiResponse<Object>> getCommentAll(Principal principal, @PathVariable Long contentId, @RequestParam(value = "cursor") Long cursor){    //cursor= last commentId
         Long memberId = MemberUtil.getMemberId(principal);
-        return ApiResponse.success(GET_COMMENT_ALL_SUCCESS, commentQueryService.getCommentAll(memberId, contentId));
+        return ApiResponse.success(GET_COMMENT_ALL_SUCCESS, commentQueryService.getCommentAll(memberId, contentId, cursor));
     }
     @GetMapping("member/{memberId}/comments")
-    public ResponseEntity<ApiResponse<Object>> getMemberComment(Principal principal, @PathVariable Long memberId){
+    public ResponseEntity<ApiResponse<Object>> getMemberComment(Principal principal, @PathVariable Long memberId, @RequestParam(value = "cursor") Long cursor){
         Long usingMemberId = MemberUtil.getMemberId(principal);
-        return ApiResponse.success(GET_MEMBER_COMMENT_SECCESS, commentQueryService.getMemberComment(usingMemberId,memberId));
+        return ApiResponse.success(GET_MEMBER_COMMENT_SECCESS, commentQueryService.getMemberComment(usingMemberId,memberId,cursor));
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
@@ -2,12 +2,12 @@ package com.dontbe.www.DontBeServer.api.comment.repository;
 
 import com.dontbe.www.DontBeServer.api.comment.domain.Comment;
 import com.dontbe.www.DontBeServer.api.content.domain.Content;
-import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.common.exception.NotFoundException;
 import com.dontbe.www.DontBeServer.common.response.ErrorStatus;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -15,11 +15,18 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findCommentById(Long commentId);
 
-    Comment findCommentByMember(Member member);
+    //게시물에 해당하는 답글 리스트 조회
+    @Query("SELECT c FROM Comment c WHERE c.id <= ?1 AND c.content.id = ?2 ORDER BY c.createdAt DESC")
+    Slice<Comment> findContentNextPage(Long lastCommentId, Long contentId, PageRequest pageRequest);
 
-    List<Comment> findCommentsByContentIdOrderByCreatedAtAsc(Long contentId);
+    Slice<Comment> findCommentsTopByContentIdOrderByCreatedAtDesc(Long contentId, PageRequest pageRequest);
 
-    List<Comment> findCommentsByMemberIdOrderByCreatedAtAsc(Long memberId);
+    //멤버에 해당하는 답글 리스트 조회
+    @Query("SELECT c FROM Comment c WHERE c.id <= ?1 AND c.member.id = ?2  ORDER BY c.createdAt DESC")
+    Slice<Comment> findMemberNextPage(Long lastCommentId, Long memberId,PageRequest pageRequest);
+
+    Slice<Comment> findCommentsTopByMemberIdOrderByCreatedAtDesc(Long memberId, PageRequest pageRequest);
+
 
     default Comment findCommentByIdOrThrow(Long commentId) {
         return findCommentById(commentId)

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
@@ -57,7 +57,7 @@ public class CommentQueryService {
         PageRequest pageRequest = PageRequest.of(0, DEFAULT_PAGE_SIZE);
         Slice<Comment> commentList;
 
-        if (cursor==0) {
+        if (cursor==-1) {
             commentList = commentRepository.findCommentsTopByMemberIdOrderByCreatedAtDesc(memberId, pageRequest);
 
         } else {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #77 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
커서기반 페이지네이션을 구현하였습니다.
처음 조회 시 가장 최근 답글이 조회되도록(Top이용)구현하였습니다.
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/355008f7-ad19-4969-8f70-2a7015f6d634)


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
