### PR TITLE
[FEAT]투명도 클릭시 -85가 되면 제한 노티 생성 + 노티 리스트 조회 로직 수정

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
@@ -15,12 +15,12 @@ public record NotificationAllResponseDto(
         String notificationText, //	댓글 노티에 나올 댓글 내용
         boolean isNotificationChecked    //	유저가 확인한 노티인지 아닌지
 ) {
-    public static NotificationAllResponseDto of(Member usingMember, Member triggerMember, Notification notification,
+    public static NotificationAllResponseDto of(Member usingMember, String triggerMemberNickname, Notification notification,
                                                 boolean isNotificationChecked, Long notificationTriggerId, String imageUrl) {
         return new NotificationAllResponseDto(
                 usingMember.getId(),
                 usingMember.getNickname(),
-                triggerMember.getNickname(),
+                triggerMemberNickname,
                 imageUrl,
                 notification.getNotificationTriggerType(),
                 TimeUtilCustom.refineTime(notification.getCreatedAt()),

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus {
     UNEXITST_CONMMENT_LIKE("좋아요를 누르지 않은 답글입니다."),
     DUPLICATION_MEMBER_GHOST("이미 투명도를 누른 대상입니다."),
     NICKNAME_VALIDATE_ERROR("이미 존재하는 닉네임입니다."),
+    GHOST_MYSELF_BLOCK("본인의 투명도를 내릴 수 없습니다."),
 
     /**
      * 401 UNAUTHORIZED


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #75 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 투명도 클릭 시 상대방의 투명도가 -85가 된다면 userBan노티도 동시에 날리게 기능을 추가했습니다.
* 노티 리스트 조회 로직에서 triggerId가 -1이거나 triggerMemberId가 -1일 경우 유저나 답글, 게시글을 찾을 수 없다고 나오는 오류를 수정했습니다.
<img width="1425" alt="스크린샷 2024-01-17 오전 7 42 27" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/fa37ecf6-8086-46b6-81ac-61a20148135f">
<img width="1350" alt="스크린샷 2024-01-17 오전 7 42 42" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/935299bd-fe6c-4122-8b4e-a090f1c9716d">

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
