### PR TITLE
[FIX]게시글에 해당하는 답글 조회에서 고스트 여부 체크 로직 수정

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
@@ -105,7 +105,7 @@ public class CommentQueryService {
 
     private boolean checkGhost(Long usingMemberId, Long commentId) {
         Member writerMember = commentRepository.findCommentByIdOrThrow(commentId).getMember();
-        return ghostRepository.existsByGhostTargetMemberIdAndGhostTriggerMemberId(usingMemberId, writerMember.getId());
+        return ghostRepository.existsByGhostTargetMemberIdAndGhostTriggerMemberId(writerMember.getId(), usingMemberId);
     }
 
     private boolean checkLikedComment(Long usingMemberId, Long commentId) {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #99 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
게시글에 해당하는 답글 조회에서 고스트 여부를 체킹하는 로직을 수정했습니다.
targetMember -> commentWriter // triggerMember -> principalMember

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
