### PR TITLE
[FIX] commentGhost시 contentId가 반환되므로 게시물 삭제 시 contentId로 검색 후 삭제

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
@@ -47,7 +47,8 @@ public class ContentCommandService {
         List<Comment> comments = commentRepository.findCommentsByContentId(contentId);
         for(Comment comment : comments) {
             notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentLiked",comment.getId());
-            notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",comment.getId());
+//            notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",comment.getId());   //변경 후 다시 바꾸기
+            notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",contentId);
             notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("comment", comment.getId());
             commentLikedRepository.deleteByComment(comment);
 //            commentRepository.deleteById(comment.getId());

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/Impl/MemberServiceImpl.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/Impl/MemberServiceImpl.java
@@ -70,7 +70,7 @@ public class MemberServiceImpl implements MemberService {
                 .notificationTargetMember(targetMember)
                 .notificationTriggerMemberId(memberId)
                 .notificationTriggerType(memberClickGhostRequestDto.alarmTriggerType())
-                .notificationTriggerId(memberClickGhostRequestDto.alarmTriggerId())
+                .notificationTriggerId(memberClickGhostRequestDto.alarmTriggerId()) //2차 스프린트 : 에러수정을 위한 notificationTriggerId에 답글id 저장, 알림 조회시 답글id로 게시글id 반환하도록하기(refineNotificationTriggerId에 추가)
                 .isNotificationChecked(false)
                 .notificationText("")
                 .build();


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #114 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
로직 변경 전 notificationTriggerId에 댓글에 관한 알림 발생 시 contentID를 RequestParam으로 받아오도록 했었기 때문에 현재 댓글 투명도 적용 시 notificationTriggerId에 contentId가 저장됩니다. 
현재 로직 상 게시물 삭제 시 TriggerType이 commentGhost면 commentId(로직 변경 후 방법)으로 JPA를 사용하고 있기 때문에 게시물이 삭제되어도 notification이 삭제되지 않아서 404에러를 발생합니다.

이때 해결할 수 있는 2가지 방법은 다음과 같습니다.
1. TriggerId에 댓글 id 저장
2. 게시글 삭제 시 commentGhost면 contentId로 검색하여 delete

>> 2번으로 코드를 수정하였습니다

하지만 2차 스프린트땐 1번 방법으로 수정되어야 하는 부분이라고 생각합니다.
1. 답글이 삭제되어도 노티가 삭제되지 않아서 답글이 없는 해당 게시물로 이동이 가능합니다.(에러는 발생하지 않습니다.
2. 현재 로직 상 ( 댓글 관련 노티) 이 방법이 맞다고 판단됩니다. (하지만 API명세서를 수정하지 못한 제 문제라고 생각되어 데모데이가 직전인 지금 클라쌤들한테 수정 요청드리기가 어렵다고 판단하여 이 방법으로 추후 스프린트를 진행하는 것이 맞다고 판단하였습니다.)

![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/6b201a8d-cd6e-402a-8a96-535ab98e62af)
홍박사님 토큰으로 보람쓰 댓글 투명도 적용하였고 홍박사님 일어나시면 PR 검토 후 배포 후 해당 게시물 삭제해보면서 문제가 해결되었는지 확인해야합니다!!!

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
