### PR TITLE
[FIX] 게시물에 해당하는 답글 순서 변경 #120

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/repository/CommentRepository.java
@@ -20,14 +20,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findCommentById(Long commentId);
 
-    List<Comment> findCommentsByContentIdOrderByCreatedAtDesc(Long contentId);
-
     List<Comment> findCommentsByMemberIdOrderByCreatedAtDesc(Long memberId);
 
     List<Comment> findCommentsByContentIdOrderByCreatedAtAsc(Long contentId);
     /*
     //게시물에 해당하는 답글 리스트 조회
-    @Query("SELECT c FROM Comment c WHERE c.id <= ?1 AND c.content.id = ?2 ORDER BY c.createdAt DESC")
+    @Query("SELECT c FROM Comment c WHERE c.id <= ?1 AND c.content.id = ?2 ORDER BY c.createdAt Asc")
     Slice<Comment> findContentNextPage(Long lastCommentId, Long contentId, PageRequest pageRequest);
 
     Slice<Comment> findCommentsTopByContentIdOrderByCreatedAtDesc(Long contentId, PageRequest pageRequest);

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
@@ -30,7 +30,7 @@ public class CommentQueryService {
     private final int DEFAULT_PAGE_SIZE = 20;
 
     public List<CommentAllResponseDto> getCommentAll(Long memberId, Long contentId) {
-        List<Comment> commentList = commentRepository.findCommentsByContentIdOrderByCreatedAtDesc(contentId);
+        List<Comment> commentList = commentRepository.findCommentsByContentIdOrderByCreatedAtAsc(contentId);
 
         return commentList.stream()
                 .map( oneComment -> CommentAllResponseDto.of(
@@ -64,7 +64,7 @@ public class CommentQueryService {
         Slice<Comment> commentList;
 
         if (cursor==-1) {
-             commentList = commentRepository.findCommentsTopByContentIdOrderByCreatedAtDesc(contentId, pageRequest);
+             commentList = commentRepository.findCommentsTopByContentIdOrderByCreatedAtAsc(contentId, pageRequest);
         } else {
             commentList = commentRepository.findContentNextPage(cursor, contentId, pageRequest);
         }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #120 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
게시글에 해당하는 답글 순서를 오래된 답글이 먼저 조회되도록 수정했습니다!

![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/ed553074-db47-47cc-8507-17f8ea15a4e8)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
