### PR TITLE
[FEAT]500에러와 토큰 관련 에러 슬랙 알림 기능 추가

### DIFF
--- a/DontBeServer/build.gradle
+++ b/DontBeServer/build.gradle
@@ -49,6 +49,13 @@ dependencies {
 	//* Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+	//* Slack Webhook
+	implementation 'com.slack.api:slack-api-client:1.28.0'
+	implementation 'com.google.code.gson:gson:2.10.1'
+	implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+	implementation 'com.slack.api:slack-app-backend:1.28.0'
+	implementation 'com.slack.api:slack-api-model:1.28.0'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/HealthCheckController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/HealthCheckController.java
@@ -1,10 +1,15 @@
 package com.dontbe.www.DontBeServer.api;
 
+import com.dontbe.www.DontBeServer.common.exception.UnAuthorizedException;
+import com.dontbe.www.DontBeServer.common.response.ApiResponse;
+import com.dontbe.www.DontBeServer.common.response.ErrorStatus;
 import com.dontbe.www.DontBeServer.common.util.MemberUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
@@ -19,5 +24,11 @@ public class HealthCheckController {
     public Long healthCheck(Principal principal) {
         return MemberUtil.getMemberId(principal);
 //        return "OK";
+    }
+
+    @GetMapping("test")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse test() throws Exception {
+        throw new Exception(ErrorStatus.INTERNAL_SERVER_ERROR.getMessage());
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentCommendService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentCommendService.java
@@ -124,7 +124,7 @@ public class CommentCommendService {
                     (targetMember, memberId,"commentLiked", comment.getId());
 
         }else{ //댓글좋아요 엔티티에 존재하지 않을 경우 예외처리
-            throw new BadRequestException(ErrorStatus.UNEXITST_COMENT_LIKE.getMessage());
+            throw new BadRequestException(ErrorStatus.UNEXIST_COMMENT_LIKE.getMessage());
         }
     }
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/advice/ControllerExceptionAdvice.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/advice/ControllerExceptionAdvice.java
@@ -1,23 +1,33 @@
 package com.dontbe.www.DontBeServer.common.advice;
 
+import java.io.IOException;
 import java.util.Objects;
 
 import com.dontbe.www.DontBeServer.common.exception.BaseException;
 import com.dontbe.www.DontBeServer.common.response.ApiResponse;
 import com.dontbe.www.DontBeServer.common.response.ErrorStatus;
+import com.dontbe.www.DontBeServer.common.util.SlackUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Component
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class ControllerExceptionAdvice {
+    private final SlackUtil slackUtil;
 
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ApiResponse> handleGlobalException(BaseException ex) {
+    public ResponseEntity<ApiResponse> handleGlobalException(BaseException ex, final Exception error, final HttpServletRequest request) throws IOException {
+        slackUtil.sendAlert(error, request);
         return ResponseEntity.status(ex.getStatusCode())
                 .body(ApiResponse.fail(ex.getStatusCode(), ex.getResponseMessage()));
     }
@@ -30,17 +40,29 @@ public class ControllerExceptionAdvice {
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse>  handleIllegalArgument(IllegalArgumentException ex) {
+    public ResponseEntity<ApiResponse> handleIllegalArgument(IllegalArgumentException ex, final Exception error, final HttpServletRequest request) throws IOException {
+        slackUtil.sendAlert(error, request);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ApiResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+    protected ResponseEntity<ApiResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e, final Exception error, final HttpServletRequest request) throws IOException {
+        slackUtil.sendAlert(error, request);
         FieldError fieldError = Objects.requireNonNull(e.getFieldError());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(),String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField())));
     }
 
+    /**
+     * 500 Internal Server
+     */
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse> handleException(Exception ex, final Exception error, final HttpServletRequest request) throws IOException {
+        slackUtil.sendAlert(error,request);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
+    }
 }
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/config/jwt/JwtTokenProvider.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/config/jwt/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package com.dontbe.www.DontBeServer.common.config.jwt;
 
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
+import com.dontbe.www.DontBeServer.common.util.SlackUtil;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -11,8 +12,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 
+import java.io.IOException;
 import java.security.Key;
 import java.util.Date;
 
@@ -30,6 +34,8 @@ public class JwtTokenProvider {
 
     @Value("${jwt.refresh-token.expire-length}")
     private Long refreshTokenExpireLength;
+
+    private final SlackUtil slackUtil;
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String REFRESH_AUTHORIZATION_HEADER = "Refresh";
@@ -91,23 +97,33 @@ public class JwtTokenProvider {
     }
 
     // 토큰 유효성 검증
-    public JwtExceptionType validateToken(String token) {
+    public JwtExceptionType validateToken(String token) throws IOException {
         try {
             Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token).getBody();
             return JwtExceptionType.VALID_JWT_TOKEN;
         } catch (io.jsonwebtoken.security.SignatureException exception) {
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            slackUtil.sendAlert(exception, request);
             log.error("잘못된 JWT 서명을 가진 토큰입니다.");
             return JwtExceptionType.INVALID_JWT_SIGNATURE;
         } catch (MalformedJwtException exception) {
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            slackUtil.sendAlert(exception, request);
             log.error("잘못된 JWT 토큰입니다.");
             return JwtExceptionType.INVALID_JWT_TOKEN;
         } catch (ExpiredJwtException exception) {
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            slackUtil.sendAlert(exception, request);
             log.error("만료된 JWT 토큰입니다.");
             return JwtExceptionType.EXPIRED_JWT_TOKEN;
         } catch (UnsupportedJwtException exception) {
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            slackUtil.sendAlert(exception, request);
             log.error("지원하지 않는 JWT 토큰입니다.");
             return JwtExceptionType.UNSUPPORTED_JWT_TOKEN;
         } catch (IllegalArgumentException exception) {
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            slackUtil.sendAlert(exception, request);
             log.error("JWT Claims가 비어있습니다.");
             return JwtExceptionType.EMPTY_JWT;
         }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ApiResponse.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ApiResponse.java
@@ -1,13 +1,14 @@
 package com.dontbe.www.DontBeServer.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 import org.springframework.http.ResponseEntity;
 
 @Builder
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T> {
 
     private final int status;

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
@@ -41,7 +41,7 @@ public enum ErrorStatus {
     NOT_FOUND_MEMBER("해당하는 유저가 없습니다."),
     NOT_FOUND_CONTENT("해당하는 게시물이 없습니다."),
     NOT_FOUND_COMMENT("해당하는 답글이 없습니다."),
-    UNEXITST_COMENT_LIKE("좋아요를 누르지 않은 답글입니다."),
+    UNEXIST_COMMENT_LIKE("좋아요를 누르지 않은 답글입니다."),
 
 
     /**

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/util/SlackUtil.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/util/SlackUtil.java
@@ -1,0 +1,139 @@
+package com.dontbe.www.DontBeServer.common.util;
+
+
+import static com.slack.api.model.block.composition.BlockCompositions.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import com.slack.api.Slack;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.BlockCompositions;
+import com.slack.api.webhook.WebhookPayloads;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SlackUtil {
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
+    private final static String NEW_LINE = "\n";
+    private final static String DOUBLE_NEW_LINE = "\n\n";
+    private final Environment env;
+
+    private StringBuilder sb = new StringBuilder();
+
+    // Slack으로 알림 보내기
+    public void sendAlert(Exception error, HttpServletRequest request) throws IOException {
+        final String ENV_ACTIVE = env.getActiveProfiles()[0];
+
+        // 현재 프로파일이 특정 프로파일이 아니면 알림보내지 않기
+//        if (!env.getActiveProfiles()[0].equals("set1")) {
+//            return;
+//        }
+
+        // 메시지 내용인 LayoutBlock List 생성
+        List<LayoutBlock> layoutBlocks = generateLayoutBlock(error, request);
+
+        // 슬랙의 send API과 webhookURL을 통해 생성한 메시지 내용 전송
+        Slack.getInstance().send(webhookUrl, WebhookPayloads
+                .payload(p ->
+                        // 메시지 전송 유저명
+                        p.username("Exception is detected 🚨")
+                                // 메시지 전송 유저 아이콘 이미지 URL
+                                .iconUrl(
+                                        "https://user-images.githubusercontent.com/64000241/252282249-08381e4c-15b5-42b9-8ffc-1e887e688f16.png")
+                                // 메시지 내용
+                                .blocks(layoutBlocks)));
+    }
+
+    // 전체 메시지가 담긴 LayoutBlock 생성
+    private List<LayoutBlock> generateLayoutBlock(Exception error, HttpServletRequest request) {
+        return Blocks.asBlocks(
+                getHeader("서버 측 오류로 예상되는 예외 상황이 발생하였습니다."),
+                Blocks.divider(),
+                getSection(generateErrorMessage(error)),
+                Blocks.divider(),
+                getSection(generateErrorPointMessage(request)),
+                Blocks.divider(),
+                // 이슈 생성을 위해 프로젝트의 Issue URL을 입력하여 바로가기 링크를 생성
+                getSection("<https://github.com/TeamDon-tBe/SERVER/issues|이슈 생성하러 가기>")
+        );
+    }
+
+    // 예외 정보 메시지 생성
+    private String generateErrorMessage(Exception error) {
+        sb.setLength(0);
+        sb.append("*[🔥 Exception]*" + NEW_LINE).append(error.toString()).append(DOUBLE_NEW_LINE);
+        sb.append("*[📩 From]*" + NEW_LINE).append(readRootStackTrace(error)).append(DOUBLE_NEW_LINE);
+
+        return sb.toString();
+    }
+
+    // HttpServletRequest를 사용하여 예외발생 요청에 대한 정보 메시지 생성
+    private String generateErrorPointMessage(HttpServletRequest request) {
+        sb.setLength(0);
+        sb.append("*[🧾세부정보]*" + NEW_LINE);
+        sb.append("Request URL : " + request.getRequestURL().toString() + NEW_LINE);
+        sb.append("Request Method : " + request.getMethod() + NEW_LINE);
+        sb.append("Request Time : " + new Date() + NEW_LINE);
+
+        // requestBody 가져오기
+        String requestBody = null;
+        try {
+            StringBuilder stringBuilder = new StringBuilder();
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(request.getInputStream()));
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                stringBuilder.append(line);
+            }
+            requestBody = stringBuilder.toString();
+        } catch (IOException e) {
+            // requestBody를 읽는 도중 에러가 발생했을 때 처리
+            log.error("Failed to read request body: {}", e.getMessage());
+        }
+        if (requestBody != null && !requestBody.isEmpty()) {
+            sb.append("Request Body: " + requestBody + NEW_LINE);
+        }
+
+        // header 값 가져오기
+        Enumeration<String> headerNames = request.getHeaderNames();
+        Map<String, String> headers = new HashMap<>();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            String headerValue = request.getHeader(headerName);
+            headers.put(headerName, headerValue);
+        }
+        sb.append("Headers: " + headers.toString() + NEW_LINE);
+
+        return sb.toString();
+    }
+
+    // 예외발생 클래스 정보 return
+    private String readRootStackTrace(Exception error) {
+        return error.getStackTrace()[0].toString();
+    }
+
+    // 에러 로그 메시지의 제목 return
+    private LayoutBlock getHeader(String text) {
+        return Blocks.header(h -> h.text(
+                plainText(pt -> pt.emoji(true)
+                        .text(text))));
+    }
+
+    // 에러 로그 메시지 내용 return
+    private LayoutBlock getSection(String message) {
+        return Blocks.section(s ->
+                s.text(BlockCompositions.markdownText(message)));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #127 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 500에러와 401관련 에러, valid관련 에러들을 슬렉에 알림오게 하는 기능을 개발했습니다.

<img width="908" alt="스크린샷 2024-02-08 오전 2 34 32" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/778046d1-bb7e-44b0-af74-030a85974145">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
