### PR TITLE
[REFACTOR]기존에 사용하던 닉네임 그대로 사용할 수 있게 중복 검사 로직 수정

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
@@ -59,8 +59,9 @@ public class MemberController {
 
     @GetMapping("nickname-validation")
     @Operation(summary = "유저 닉네임 사용 가능 확인 API 입니다.",description = "NicknameValidation")
-    public ResponseEntity<ApiResponse<Object>> checkMemberNickname(Principal principal,@RequestParam(value = "nickname") String nickname) {
-        memberQueryService.checkNicknameValidate(nickname);
+    public ResponseEntity<ApiResponse<Object>> checkMemberNickname(Principal principal, @RequestParam(value = "nickname") String nickname) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        memberQueryService.checkNicknameValidate(memberId, nickname);
         return ApiResponse.success(NICKNAME_CHECK_SUCCESS);
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberQueryService.java
@@ -30,7 +30,13 @@ public class MemberQueryService {
         return MemberGetProfileResponseDto.of(member, memberGhost);
     }
 
-    public void checkNicknameValidate(String nickname) {
+    public void checkNicknameValidate(Long memberId, String nickname) {
+        String userNickname = memberRepository.findMemberByIdOrThrow(memberId).getNickname();
+
+        if (nickname.equals(userNickname)) {
+            return;
+        }
+
         if(memberRepository.existsByNickname(nickname)){
             throw new BadRequestException(ErrorStatus.NICKNAME_VALIDATE_ERROR.getMessage());
         }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #133 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 현재 프로필 편집 부분에서 한 줄 소개만 수정할 경우 닉네임을 그대로 사용하는데, 이때 닉네임 중복 검사에서 통과하지 못하는 이슈가 발생하여 이를 수정합니다.
* 사용자 JWT accessToken을 사용하여 본인이 사용하던 닉네임일 경우 에러를 발생시키지 않게 처리합니다.

<img width="1302" alt="스크린샷 2024-02-12 오전 2 27 00" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/94c158d3-0fa8-4804-adfa-29a565d1cdd4">
<img width="1373" alt="스크린샷 2024-02-12 오전 2 27 48" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/dc0bab82-104e-4e16-a75c-790740e03a2b">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
