### PR TITLE
[REFACTOR] 게시글 softdelete 적용 #132

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
@@ -20,7 +20,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-@Where(clause = "isDeleted = false")
+@Where(clause = "is_deleted = false")
 public class Content extends BaseTimeEntity {
 
     private static final long CONTENT_RETENTION_PERIOD = 14L;   // 게시글 삭제 후 보유기간 14일로 설정

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
@@ -5,7 +5,6 @@ import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
@@ -42,7 +42,8 @@ public class Content extends BaseTimeEntity {
     @OneToMany(mappedBy = "content", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    private boolean isDeleted = Boolean.FALSE;
+    @Column(name = "is_deleted", columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean isDeleted;
 
     private LocalDateTime deleteAt;
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@Where(clause = "isDeleted = false")
 public class Content extends BaseTimeEntity {
 
     private static final long CONTENT_RETENTION_PERIOD = 14L;   // 게시글 삭제 후 보유기간 14일로 설정
@@ -40,7 +42,7 @@ public class Content extends BaseTimeEntity {
     @OneToMany(mappedBy = "content", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    private boolean isDeleted = false;
+    private boolean isDeleted = Boolean.FALSE;
 
     private LocalDateTime deleteAt;
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/domain/Content.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +20,9 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class Content extends BaseTimeEntity {
+
+    private static final long CONTENT_RETENTION_PERIOD = 14L;   // 게시글 삭제 후 보유기간 14일로 설정
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -35,9 +39,20 @@ public class Content extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "content", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
+
+    private boolean isDeleted = false;
+
+    private LocalDateTime deleteAt;
+
     @Builder
     public Content(Member member, String contentText) {
         this.member = member;
         this.contentText = contentText;
     }
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deleteAt = LocalDateTime.now().plusDays(CONTENT_RETENTION_PERIOD);
+    }
+
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/repository/ContentRepository.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/repository/ContentRepository.java
@@ -8,11 +8,15 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface ContentRepository extends JpaRepository<Content, Long> {
     Optional<Content> findContentById(Long contentId);
+
+    @Query("DELETE FROM Content c WHERE c.isDeleted = true AND c.deleteAt < :currentDate")
+    void deleteContentScheduledForDeletion(LocalDateTime currentDate);
 
     //게시물 전체 조회 관련
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
@@ -58,7 +58,9 @@ public class ContentCommandService {
         }
         notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("contentLiked",contentId);
         notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("contentGhost",contentId);
-        contentRepository.deleteById(contentId);
+        Content deleteContent = contentRepository.findContentByIdOrThrow(contentId);
+        deleteContent.softDelete();
+
     }
 
     public void likeContent(Long memberId, Long contentId, ContentLikedRequestDto contentLikedRequestDto) {
@@ -104,6 +106,7 @@ public class ContentCommandService {
         notificationRepository.deleteByNotificationTargetMemberAndNotificationTriggerMemberIdAndNotificationTriggerTypeAndNotificationTriggerId(
                 targetMember, memberId, "contentLiked", contentId);
     }
+
 
     private void deleteValidate(Long memberId, Long contentId) {
         Content content = contentRepository.findById(contentId)

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ExpiredContentDeleteBatch.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ExpiredContentDeleteBatch.java
@@ -1,0 +1,22 @@
+package com.dontbe.www.DontBeServer.api.content.service;
+
+
+import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ExpiredContentDeleteBatch {
+    private final ContentRepository contentRepository;
+
+    @Scheduled(cron = "0 0 0 * * ?")    //매일 밤 자정에 실행
+    public void deleteExpiredUser() {
+        contentRepository.deleteContentScheduledForDeletion(LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #132 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
게시글 삭제 시 is_deleted(기본값 : 0)가 1로 바뀌고 14일 뒤 물리적으로 삭제됩니다.
논리적으로 삭제된 게시글은 조회되지 않습니다.
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/8c11c8cb-35af-43d9-8973-e0453d276b46)
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/23f85355-22d8-470d-b7ee-5fbe5a4e57c0)
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/352c17b9-73ed-4fdd-a5b9-0e255039fa7a)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
현재 모든 soft delete를 @where 어노테이션을 사용하여 구현할 예정입니다! 
하지만 해당 어노테이션에 대한 이슈를 알고있어서 다음 스프린트 때 JPQL을 도입할 예정입니다
관련 아카이빙은 [노션](https://www.notion.so/7d346c3d25fe4a249df696eb4c378007)에서 확인하실 수 있습니다!

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
