### PR TITLE
[FIX] 게시글 삭제 시 해당 게시글에 달린 답글의 commentGhost 노티 삭제되도록 수정

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
@@ -50,8 +50,7 @@ public class ContentCommandService {
         List<Comment> comments = commentRepository.findCommentsByContentId(contentId);
         for(Comment comment : comments) {
             notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentLiked",comment.getId());
-            //notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",comment.getId());   //변경 후 다시 바꾸기
-            notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",contentId);
+            notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",comment.getId());
             notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("comment", comment.getId());
         }
         notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("contentLiked",contentId);

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/ghost/service/GhostCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/ghost/service/GhostCommandService.java
@@ -41,7 +41,7 @@ public class GhostCommandService {
                 .notificationTargetMember(targetMember)
                 .notificationTriggerMemberId(memberId)
                 .notificationTriggerType(memberClickGhostRequestDto.alarmTriggerType())
-                .notificationTriggerId(memberClickGhostRequestDto.alarmTriggerId()) //2차 스프린트 : 에러수정을 위한 notificationTriggerId에 답글id 저장, 알림 조회시 답글id로 게시글id 반환하도록하기(refineNotificationTriggerId에 추가)
+                .notificationTriggerId(memberClickGhostRequestDto.alarmTriggerId())
                 .isNotificationChecked(false)
                 .notificationText("")
                 .build();
@@ -80,7 +80,7 @@ public class GhostCommandService {
                 .notificationTargetMember(targetMember)
                 .notificationTriggerMemberId(memberId)
                 .notificationTriggerType(ghostClickRequestDto.alarmTriggerType())
-                .notificationTriggerId(ghostClickRequestDto.alarmTriggerId()) //2차 스프린트 : 에러수정을 위한 notificationTriggerId에 답글id 저장, 알림 조회시 답글id로 게시글id 반환하도록하기(refineNotificationTriggerId에 추가)
+                .notificationTriggerId(ghostClickRequestDto.alarmTriggerId())
                 .isNotificationChecked(false)
                 .notificationText("")
                 .build();

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
@@ -61,8 +61,7 @@ public class MemberCommandService {
             List<Comment> comments = commentRepository.findCommentsByContentId(contentId);
             for(Comment comment : comments) {
                 notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentLiked",comment.getId());
-//            notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",comment.getId());   //변경 후 다시 바꾸기
-                notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",contentId);
+                notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",comment.getId());
                 notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("comment", comment.getId());
             }
             notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("contentLiked",contentId);

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
@@ -76,8 +76,8 @@ public class NotificationQueryService {
     private long refineNotificationTriggerId (String triggerType, Long triggerId, Notification notification){
 
 //        Comment comment = commentRepository.findCommentByIdOrThrow(triggerId);
-        //답글관련(답글좋아요 혹은 답글 작성)시 게시물 id 반환
-        if(triggerType.equals("comment") || triggerType.equals("commentLiked")) {
+        //답글관련(답글좋아요 혹은 답글 작성, 답글 투명도)시 게시물 id 반환
+        if(triggerType.equals("comment") || triggerType.equals("commentLiked") || triggerType.equals("commentGhost")) {
             Comment comment = commentRepository.findCommentByIdOrThrow(triggerId);
             return comment.getContent().getId();
         }else{


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #122 
- 
## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
 게시글 삭제 시 노티에서 게시글에 해당하는 답글id 값으로 노티가 삭제되도록 하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
기존에 생성된 노티 중 commentGhost 노티 삭제했습니다! 배포 후 한번 더 확인하겠습니다

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/57d3e476-6316-43a0-baf7-dbbc2c67139e)
게시글에 답글 작성 후 투명도 적용 해보았고 해당 게시물을 삭제했을 때 노티가 삭제됨을 확인했습니다.