### PR TITLE
[Feat] response에 isDeleted 추가

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllResponseDto.java
@@ -1,7 +1,6 @@
 package com.dontbe.www.DontBeServer.api.comment.dto.response;
 
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
-import com.dontbe.www.DontBeServer.api.comment.domain.Comment;
 
 public record CommentAllResponseDto(
         Long commentId, //답글 고유 id
@@ -13,7 +12,8 @@ public record CommentAllResponseDto(
         Boolean isLiked,	//유저가 게시물에 대해 좋아요를 눌렀는지
         int commentLikedNumber,	//댓글의 좋아요 개수
         String commentText,	//댓글 내용
-        String  time	//답글이 작성된 시간을 (년-월-일 시:분:초)
+        String  time,	//답글이 작성된 시간을 (년-월-일 시:분:초)
+        Boolean isDeleted   // 댓글 작성자가 탈퇴한 회원인지 아닌지
 ) {
     public static CommentAllResponseDto of(Long commentId, Member writerMember,boolean isGhost,int memberGhost, boolean isLiked, String time, int likedNumber, String commentText){
         return new CommentAllResponseDto(
@@ -26,7 +26,8 @@ public record CommentAllResponseDto(
                 isLiked,
                 likedNumber,
                 commentText,
-                time
+                time,
+                writerMember.isDeleted()
         );
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllResponseDto.java
@@ -3,18 +3,19 @@ package com.dontbe.www.DontBeServer.api.comment.dto.response;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 
 public record CommentAllResponseDto(
-                                     Long commentId, //답글 고유 id
-                                     Long memberId,  //	댓글 작성자 Id
-                                     String memberProfileUrl,     //작성자 프로필 사진url
-                                     String memberNickname,	//댓글 작성자 닉네임
-                                     Boolean isGhost,	//현재 유저가 작성자에 대해 투명도 처리를 했는지
-                                     int memberGhost,	//작성자의 전체 투명도
-                                     Boolean isLiked,	//유저가 게시물에 대해 좋아요를 눌렀는지
-                                     int commentLikedNumber,	//댓글의 좋아요 개수
-                                     String commentText,	//댓글 내용
-                                     String  time	//답글이 작성된 시간을 (년-월-일 시:분:초)
+        Long commentId, //답글 고유 id
+        Long memberId,  //	댓글 작성자 Id
+        String memberProfileUrl,     //작성자 프로필 사진url
+        String memberNickname,	//댓글 작성자 닉네임
+        Boolean isGhost,	//현재 유저가 작성자에 대해 투명도 처리를 했는지
+        int memberGhost,	//작성자의 전체 투명도
+        Boolean isLiked,	//유저가 게시물에 대해 좋아요를 눌렀는지
+        int commentLikedNumber,	//댓글의 좋아요 개수
+        String commentText,	//댓글 내용
+        String  time	//답글이 작성된 시간을 (년-월-일 시:분:초)
 ) {
-    public static CommentAllResponseDto of(Long commentId, Member writerMember, boolean isGhost, int memberGhost, boolean isLiked, String time, int likedNumber, String commentText){
+    public static CommentAllResponseDto of(Long commentId, Member writerMember, boolean isGhost, int memberGhost,
+                                           boolean isLiked, String time, int likedNumber, String commentText){
         return new CommentAllResponseDto(
                 commentId,
                 writerMember.getId(),

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllResponseDto.java
@@ -3,19 +3,18 @@ package com.dontbe.www.DontBeServer.api.comment.dto.response;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 
 public record CommentAllResponseDto(
-        Long commentId, //답글 고유 id
-        Long memberId,  //	댓글 작성자 Id
-        String memberProfileUrl,     //작성자 프로필 사진url
-        String memberNickname,	//댓글 작성자 닉네임
-        Boolean isGhost,	//현재 유저가 작성자에 대해 투명도 처리를 했는지
-        int memberGhost,	//작성자의 전체 투명도
-        Boolean isLiked,	//유저가 게시물에 대해 좋아요를 눌렀는지
-        int commentLikedNumber,	//댓글의 좋아요 개수
-        String commentText,	//댓글 내용
-        String  time,	//답글이 작성된 시간을 (년-월-일 시:분:초)
-        Boolean isDeleted   // 댓글 작성자가 탈퇴한 회원인지 아닌지
+                                     Long commentId, //답글 고유 id
+                                     Long memberId,  //	댓글 작성자 Id
+                                     String memberProfileUrl,     //작성자 프로필 사진url
+                                     String memberNickname,	//댓글 작성자 닉네임
+                                     Boolean isGhost,	//현재 유저가 작성자에 대해 투명도 처리를 했는지
+                                     int memberGhost,	//작성자의 전체 투명도
+                                     Boolean isLiked,	//유저가 게시물에 대해 좋아요를 눌렀는지
+                                     int commentLikedNumber,	//댓글의 좋아요 개수
+                                     String commentText,	//댓글 내용
+                                     String  time	//답글이 작성된 시간을 (년-월-일 시:분:초)
 ) {
-    public static CommentAllResponseDto of(Long commentId, Member writerMember,boolean isGhost,int memberGhost, boolean isLiked, String time, int likedNumber, String commentText){
+    public static CommentAllResponseDto of(Long commentId, Member writerMember, boolean isGhost, int memberGhost, boolean isLiked, String time, int likedNumber, String commentText){
         return new CommentAllResponseDto(
                 commentId,
                 writerMember.getId(),
@@ -26,8 +25,7 @@ public record CommentAllResponseDto(
                 isLiked,
                 likedNumber,
                 commentText,
-                time,
-                writerMember.isDeleted()
+                time
         );
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllResponseDtoVer2.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/dto/response/CommentAllResponseDtoVer2.java
@@ -1,0 +1,33 @@
+package com.dontbe.www.DontBeServer.api.comment.dto.response;
+
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
+
+public record CommentAllResponseDtoVer2(
+        Long commentId, //답글 고유 id
+        Long memberId,  //	댓글 작성자 Id
+        String memberProfileUrl,     //작성자 프로필 사진url
+        String memberNickname,	//댓글 작성자 닉네임
+        Boolean isGhost,	//현재 유저가 작성자에 대해 투명도 처리를 했는지
+        int memberGhost,	//작성자의 전체 투명도
+        Boolean isLiked,	//유저가 게시물에 대해 좋아요를 눌렀는지
+        int commentLikedNumber,	//댓글의 좋아요 개수
+        String commentText,	//댓글 내용
+        String  time,	//답글이 작성된 시간을 (년-월-일 시:분:초)
+        Boolean isDeleted   // 댓글 작성자가 탈퇴한 회원인지 아닌지
+) {
+    public static CommentAllResponseDtoVer2 of(Long commentId, Member writerMember, boolean isGhost, int memberGhost, boolean isLiked, String time, int likedNumber, String commentText){
+        return new CommentAllResponseDtoVer2(
+                commentId,
+                writerMember.getId(),
+                writerMember.getProfileUrl(),
+                writerMember.getNickname(),
+                isGhost,
+                memberGhost,
+                isLiked,
+                likedNumber,
+                commentText,
+                time,
+                writerMember.isDeleted()
+        );
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentQueryService.java
@@ -3,6 +3,7 @@ package com.dontbe.www.DontBeServer.api.comment.service;
 import com.dontbe.www.DontBeServer.api.comment.domain.Comment;
 import com.dontbe.www.DontBeServer.api.comment.dto.response.CommentAllByMemberResponseDto;
 import com.dontbe.www.DontBeServer.api.comment.dto.response.CommentAllResponseDto;
+import com.dontbe.www.DontBeServer.api.comment.dto.response.CommentAllResponseDtoVer2;
 import com.dontbe.www.DontBeServer.api.comment.repository.CommentLikedRepository;
 import com.dontbe.www.DontBeServer.api.comment.repository.CommentRepository;
 import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
@@ -64,7 +65,7 @@ public class CommentQueryService {
                 ).collect(Collectors.toList());
     }
 
-    public List<CommentAllResponseDto> getCommentAllPagination(Long memberId, Long contentId, Long cursor) {
+    public List<CommentAllResponseDtoVer2> getCommentAllPagination(Long memberId, Long contentId, Long cursor) {
         contentRepository.findContentByIdOrThrow(contentId);
         PageRequest pageRequest = PageRequest.of(0, COMMENT_DEFAULT_PAGE_SIZE);
         Slice<Comment> commentList;
@@ -72,7 +73,7 @@ public class CommentQueryService {
         commentList = commentRepository.findCommentsByContentNextPage(cursor, contentId, pageRequest);
 
         return commentList.stream()
-                .map(oneComment -> CommentAllResponseDto.of(
+                .map(oneComment -> CommentAllResponseDtoVer2.of(
                         oneComment.getId(),
                         memberRepository.findMemberByIdOrThrow(oneComment.getMember().getId()),
                         checkGhost(memberId, oneComment.getId()),

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
@@ -80,7 +80,7 @@ public class ContentController {
 
     @GetMapping("/contents")
     @Operation(summary = "페이지네이션이 적용된 게시글 전체 조회 API 입니다.",description = "ContentGetPagination")
-    public ResponseEntity<ApiResponse<List<ContentGetAllResponseDto>>> getContentAllPagination(Principal principal, @RequestParam(value = "cursor") Long cursor) {
+    public ResponseEntity<ApiResponse<List<ContentGetAllResponseDtoVer2>>> getContentAllPagination(Principal principal, @RequestParam(value = "cursor") Long cursor) {
         Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponse.success(GET_CONTENT_ALL_SUCCESS, contentQueryService.getContentAllPagination(memberId, cursor));
     }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/dto/response/ContentGetAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/dto/response/ContentGetAllResponseDto.java
@@ -14,7 +14,8 @@ public record ContentGetAllResponseDto (
         int memberGhost,
         boolean isLiked,
         int likedNumber,
-        int commentNumber
+        int commentNumber,
+        Boolean isDeleted
 ) {
     public static ContentGetAllResponseDto of(Member writerMember, Content content, boolean isGhost,int refinedMemberGhost, boolean isLiked, String time, int likedNumber, int commentNumber) {
         return new ContentGetAllResponseDto(
@@ -28,7 +29,8 @@ public record ContentGetAllResponseDto (
                 refinedMemberGhost,
                 isLiked,
                 likedNumber,
-                commentNumber
+                commentNumber,
+                writerMember.isDeleted()
         );
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/dto/response/ContentGetAllResponseDtoVer2.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/dto/response/ContentGetAllResponseDtoVer2.java
@@ -3,7 +3,7 @@ package com.dontbe.www.DontBeServer.api.content.dto.response;
 import com.dontbe.www.DontBeServer.api.content.domain.Content;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 
-public record ContentGetAllResponseDto(
+public record ContentGetAllResponseDtoVer2(
         Long memberId,
         String memberProfileUrl,
         String memberNickname,
@@ -14,10 +14,11 @@ public record ContentGetAllResponseDto(
         int memberGhost,
         boolean isLiked,
         int likedNumber,
-        int commentNumber
+        int commentNumber,
+        Boolean isDeleted
 ) {
-    public static ContentGetAllResponseDto of(Member writerMember, Content content, boolean isGhost, int refinedMemberGhost, boolean isLiked, String time, int likedNumber, int commentNumber) {
-        return new ContentGetAllResponseDto(
+    public static ContentGetAllResponseDtoVer2 of(Member writerMember, Content content, boolean isGhost, int refinedMemberGhost, boolean isLiked, String time, int likedNumber, int commentNumber) {
+        return new ContentGetAllResponseDtoVer2(
                 writerMember.getId(),
                 writerMember.getProfileUrl(),
                 writerMember.getNickname(),
@@ -28,7 +29,8 @@ public record ContentGetAllResponseDto(
                 refinedMemberGhost,
                 isLiked,
                 likedNumber,
-                commentNumber
+                commentNumber,
+                writerMember.isDeleted()
         );
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentQueryService.java
@@ -4,6 +4,7 @@ import com.dontbe.www.DontBeServer.api.comment.repository.CommentRepository;
 import com.dontbe.www.DontBeServer.api.content.domain.Content;
 import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetAllByMemberResponseDto;
 import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetAllResponseDto;
+import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetAllResponseDtoVer2;
 import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetDetailsResponseDto;
 import com.dontbe.www.DontBeServer.api.content.repository.ContentLikedRepository;
 import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
@@ -63,7 +64,7 @@ public class ContentQueryService {
                 .collect(Collectors.toList());
     }
 
-    public List<ContentGetAllResponseDto> getContentAllPagination(Long memberId, Long cursor) {
+    public List<ContentGetAllResponseDtoVer2> getContentAllPagination(Long memberId, Long cursor) {
         PageRequest pageRequest = PageRequest.of(0, 30);
         Member usingMember = memberRepository.findMemberByIdOrThrow(memberId);
         Slice<Content> contentList;
@@ -75,7 +76,7 @@ public class ContentQueryService {
         }
 
         return contentList.stream()
-                .map(oneContent -> ContentGetAllResponseDto.of(
+                .map(oneContent -> ContentGetAllResponseDtoVer2.of(
                         oneContent.getMember(),
                         oneContent,
                         ghostRepository.existsByGhostTargetMemberAndGhostTriggerMember(oneContent.getMember(),usingMember),

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
@@ -13,11 +13,10 @@ public record NotificationAllResponseDto(
         String time,	//	노티가 발생한 시간을 (년-월-일 시:분:초)
         Long notificationTriggerId ,    //	노티 발생 시 해당 경우의 Id
         String notificationText, //	댓글 노티에 나올 댓글 내용
-        boolean isNotificationChecked,    //	유저가 확인한 노티인지 아닌지
-        Boolean isDeleted   //노티 유발자가 탈퇴한 회원인지 아닌지
+        boolean isNotificationChecked    //	유저가 확인한 노티인지 아닌지
 ) {
     public static NotificationAllResponseDto of(Member usingMember, String triggerMemberNickname, Notification notification,
-                                                boolean isNotificationChecked, Long notificationTriggerId, String imageUrl, boolean isDeletedMember) {
+                                                boolean isNotificationChecked, Long notificationTriggerId, String imageUrl) {
         return new NotificationAllResponseDto(
                 usingMember.getId(),
                 usingMember.getNickname(),
@@ -27,11 +26,9 @@ public record NotificationAllResponseDto(
                 TimeUtilCustom.refineTime(notification.getCreatedAt()),
                 notificationTriggerId,
                 notification.getNotificationText(),
-                isNotificationChecked,
-                isDeletedMember
+                isNotificationChecked
 
         );
     }
 
 }
-

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDto.java
@@ -13,10 +13,11 @@ public record NotificationAllResponseDto(
         String time,	//	노티가 발생한 시간을 (년-월-일 시:분:초)
         Long notificationTriggerId ,    //	노티 발생 시 해당 경우의 Id
         String notificationText, //	댓글 노티에 나올 댓글 내용
-        boolean isNotificationChecked    //	유저가 확인한 노티인지 아닌지
+        boolean isNotificationChecked,    //	유저가 확인한 노티인지 아닌지
+        Boolean isDeleted   //노티 유발자가 탈퇴한 회원인지 아닌지
 ) {
     public static NotificationAllResponseDto of(Member usingMember, String triggerMemberNickname, Notification notification,
-                                                boolean isNotificationChecked, Long notificationTriggerId, String imageUrl) {
+                                                boolean isNotificationChecked, Long notificationTriggerId, String imageUrl, boolean isDeletedMember) {
         return new NotificationAllResponseDto(
                 usingMember.getId(),
                 usingMember.getNickname(),
@@ -26,7 +27,9 @@ public record NotificationAllResponseDto(
                 TimeUtilCustom.refineTime(notification.getCreatedAt()),
                 notificationTriggerId,
                 notification.getNotificationText(),
-                isNotificationChecked
+                isNotificationChecked,
+                isDeletedMember
+
         );
     }
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDtoVer2.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/dto/response/NotificationAllResponseDtoVer2.java
@@ -1,0 +1,37 @@
+package com.dontbe.www.DontBeServer.api.notification.dto.response;
+
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
+import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
+import com.dontbe.www.DontBeServer.common.util.TimeUtilCustom;
+
+public record NotificationAllResponseDtoVer2(
+        long memberId,   //사용하는 유저Id
+        String memberNickname,  //사용하는 유저 닉네임
+        String triggerMemberNickname,	//노티 유발자의 닉네임
+        String triggerMemberProfileUrl,	//노티 유발자 프로필 사진url
+        String notificationTriggerType,
+        String time,	//	노티가 발생한 시간을 (년-월-일 시:분:초)
+        Long notificationTriggerId ,    //	노티 발생 시 해당 경우의 Id
+        String notificationText, //	댓글 노티에 나올 댓글 내용
+        boolean isNotificationChecked,    //	유저가 확인한 노티인지 아닌지
+        Boolean isDeleted   //노티 유발자가 탈퇴한 회원인지 아닌지
+) {
+    public static NotificationAllResponseDtoVer2 of(Member usingMember, String triggerMemberNickname, Notification notification,
+                                                    boolean isNotificationChecked, Long notificationTriggerId, String imageUrl, boolean isDeletedMember) {
+        return new NotificationAllResponseDtoVer2(
+                usingMember.getId(),
+                usingMember.getNickname(),
+                triggerMemberNickname,
+                imageUrl,
+                notification.getNotificationTriggerType(),
+                TimeUtilCustom.refineTime(notification.getCreatedAt()),
+                notificationTriggerId,
+                notification.getNotificationText(),
+                isNotificationChecked,
+                isDeletedMember
+
+        );
+    }
+
+}
+

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
@@ -45,7 +45,8 @@ public class NotificationQueryService {
                         oneNotification.isNotificationChecked(),
                         refineNotificationTriggerId(oneNotification.getNotificationTriggerType(),
                                 oneNotification.getNotificationTriggerId(), oneNotification),
-                        profileUrl(oneNotification.getId(), oneNotification.getNotificationTriggerType())
+                        profileUrl(oneNotification.getId(), oneNotification.getNotificationTriggerType()),
+                        isDeletedMember(oneNotification.getNotificationTriggerMemberId())
                 )).collect(Collectors.toList());
     }
 
@@ -69,7 +70,8 @@ public class NotificationQueryService {
                         oneNotification.isNotificationChecked(),
                         refineNotificationTriggerId(oneNotification.getNotificationTriggerType(),
                                 oneNotification.getNotificationTriggerId(), oneNotification),
-                        profileUrl(oneNotification.getId(), oneNotification.getNotificationTriggerType())
+                        profileUrl(oneNotification.getId(), oneNotification.getNotificationTriggerType()),
+                        isDeletedMember(oneNotification.getNotificationTriggerMemberId())
                 )).collect(Collectors.toList());
     }
 
@@ -103,5 +105,11 @@ public class NotificationQueryService {
             return memberRepository.findMemberByIdOrThrow(memberId).getNickname();
         }
         else return "System";
+    }
+
+    //탈퇴한 회원인지 아닌지
+    private boolean isDeletedMember(Long triggerMemberId){
+        return memberRepository.findMemberByIdOrThrow(triggerMemberId).isDeleted();
+        //운영 노티인 경우 trigger의 닉네임이 따로 나오지 않아서 별도의 로직 불필요
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/notification/service/NotificationQueryService.java
@@ -7,6 +7,7 @@ import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
 import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
 import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificaitonCountResponseDto;
 import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificationAllResponseDto;
+import com.dontbe.www.DontBeServer.api.notification.dto.response.NotificationAllResponseDtoVer2;
 import com.dontbe.www.DontBeServer.api.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -45,12 +46,11 @@ public class NotificationQueryService {
                         oneNotification.isNotificationChecked(),
                         refineNotificationTriggerId(oneNotification.getNotificationTriggerType(),
                                 oneNotification.getNotificationTriggerId(), oneNotification),
-                        profileUrl(oneNotification.getId(), oneNotification.getNotificationTriggerType()),
-                        isDeletedMember(oneNotification.getNotificationTriggerMemberId())
+                        profileUrl(oneNotification.getId(), oneNotification.getNotificationTriggerType())
                 )).collect(Collectors.toList());
     }
 
-    public List<NotificationAllResponseDto> getNotificationAllPagination(Long memberId, Long cursor){
+    public List<NotificationAllResponseDtoVer2> getNotificationAllPagination(Long memberId, Long cursor){
         Member usingMember = memberRepository.findMemberByIdOrThrow(memberId);
 
         PageRequest pageRequest = PageRequest.of(0, NOTIFICATION_DEFAULT_PAGE_SIZE);
@@ -63,7 +63,7 @@ public class NotificationQueryService {
         }
 
         return notificationList.stream()
-                .map(oneNotification -> NotificationAllResponseDto.of(
+                .map(oneNotification -> NotificationAllResponseDtoVer2.of(
                         usingMember,
                         isSystemOrUser(oneNotification.getNotificationTriggerMemberId()),
                         oneNotification,


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #154 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
탈퇴한 회원 프로필 접근을 막기 위해 response에 isDeleted(Boolean)값을 추가합니다.
페이지네이션이 적용된 노티리스트조회 / 게시글 리스트조회 / 게시글에 해당하는 답글 리스트조회 3개의 api에 추가하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/77137f48-9aa3-4261-ad0d-3307cc7ae720)
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/5ab6c143-f35a-455c-a082-558a43ee6eda)
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/64cbe0cb-eaa5-469e-a89a-8ba0426a2b04)
