### PR TITLE
[FEAT]프로필 이미지 변경 기능 추가

### DIFF
--- a/DontBeServer/build.gradle
+++ b/DontBeServer/build.gradle
@@ -59,6 +59,10 @@ dependencies {
 	//* Apple Social Login
 	implementation 'com.google.code.gson:gson:2.10.1'
 
+	// AWS sdk
+	implementation("software.amazon.awssdk:bom:2.21.0")
+	implementation("software.amazon.awssdk:s3:2.21.0")
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/service/Impl/AuthServiceImpl.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/service/Impl/AuthServiceImpl.java
@@ -17,6 +17,7 @@ import com.dontbe.www.DontBeServer.common.config.jwt.UserAuthentication;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
@@ -27,7 +28,9 @@ import java.security.spec.InvalidKeySpecException;
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
     private final static String GHOST_IMAGE = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
-    private final static String GHOST_IMAGE_S3 = "https://dontbe-s3.s3.ap-northeast-2.amazonaws.com/ProfileImage/defalut/image_profile.png";
+
+    @Value("${aws-property.s3-default-image-url}")
+    private String GHOST_IMAGE_S3;
     private final static String DEFAULT_NICKNAME="";
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/service/Impl/AuthServiceImpl.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/auth/service/Impl/AuthServiceImpl.java
@@ -27,6 +27,7 @@ import java.security.spec.InvalidKeySpecException;
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
     private final static String GHOST_IMAGE = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
+    private final static String GHOST_IMAGE_S3 = "https://dontbe-s3.s3.ap-northeast-2.amazonaws.com/ProfileImage/defalut/image_profile.png";
     private final static String DEFAULT_NICKNAME="";
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.dontbe.www.DontBeServer.api.member.controller;
 
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberWithdrawRequestDto;
+import com.dontbe.www.DontBeServer.api.member.dto.request.ProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberDetailGetResponseDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberGetProfileResponseDto;
 import com.dontbe.www.DontBeServer.api.member.service.MemberCommandService;
@@ -12,8 +13,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.security.Principal;
 import static com.dontbe.www.DontBeServer.common.response.SuccessStatus.*;
 
@@ -62,6 +66,14 @@ public class MemberController {
     public ResponseEntity<ApiResponse<Object>> updateMemberProfile(Principal principal, @RequestBody MemberProfilePatchRequestDto memberProfilePatchRequestDto) {
         Long memberId = MemberUtil.getMemberId(principal);
         memberCommandService.updateMemberProfile(memberId, memberProfilePatchRequestDto);
+        return ApiResponse.success(PATCH_MEMBER_PROFILE);
+    }
+
+    @PatchMapping(value = "user-profile2", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "유저 프로필 수정 API입니다.(이미지 수정 버전 추가)",description = "UserProfilePatch(+ProfileImage)")
+    public ResponseEntity<ApiResponse<Object>> updateMemberProfile2(Principal principal, @RequestPart(value = "file", required = false) MultipartFile multipartFile, @RequestPart(value = "info", required = false) ProfilePatchRequestDto profilePatchRequestDto) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        memberCommandService.updateMemberProfile2(memberId, multipartFile, profilePatchRequestDto);
         return ApiResponse.success(PATCH_MEMBER_PROFILE);
     }
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/request/ProfilePatchRequestDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/request/ProfilePatchRequestDto.java
@@ -1,0 +1,10 @@
+package com.dontbe.www.DontBeServer.api.member.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record ProfilePatchRequestDto (
+        String nickname,
+        Boolean isAlarmAllowed,
+        String memberIntro
+){
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
@@ -40,7 +40,7 @@ public class MemberCommandService {
     private final S3Service s3Service;
     private final String DEFAULT_PROFILE_URL = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
     private final static String GHOST_IMAGE = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
-
+    private final static String GHOST_IMAGE_S3 = "https://dontbe-s3.s3.ap-northeast-2.amazonaws.com/ProfileImage/defalut/image_profile.png";
     private static final String S3_URL = "https://dontbe-s3.s3.ap-northeast-2.amazonaws.com/";
     public void withdrawalMember(Long memberId, MemberWithdrawRequestDto memberWithdrawRequestDto) {
         Member member = memberRepository.findMemberByIdOrThrow(memberId);
@@ -141,7 +141,7 @@ public class MemberCommandService {
                 String s3ImageUrl = s3Service.uploadImage(memberId.toString(), multipartFile);
                 existingMember.updateProfileUrl(s3ImageUrl);
 
-                if(!existedImage.equals(GHOST_IMAGE)) {
+                if(!existedImage.equals(GHOST_IMAGE)||!existedImage.equals(GHOST_IMAGE_S3)) {
                     String existedKey = removeBaseUrl(existedImage, S3_URL);
                     s3Service.deleteImage(existedKey);
                 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
@@ -13,13 +13,17 @@ import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberWithdrawRequestDto;
+import com.dontbe.www.DontBeServer.api.member.dto.request.ProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
 import com.dontbe.www.DontBeServer.api.notification.repository.NotificationRepository;
 import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
+import com.dontbe.www.DontBeServer.external.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -33,8 +37,11 @@ public class MemberCommandService {
     private final CommentRepository commentRepository;
     private final CommentLikedRepository commentLikedRepository;
     private final ContentLikedRepository contentLikedRepository;
+    private final S3Service s3Service;
     private final String DEFAULT_PROFILE_URL = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
+    private final static String GHOST_IMAGE = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
 
+    private static final String S3_URL = "https://dontbe-s3.s3.ap-northeast-2.amazonaws.com/";
     public void withdrawalMember(Long memberId, MemberWithdrawRequestDto memberWithdrawRequestDto) {
         Member member = memberRepository.findMemberByIdOrThrow(memberId);
         List<Ghost> ghosts = ghostRepository.findByGhostTargetMember(member);
@@ -111,8 +118,48 @@ public class MemberCommandService {
         if (memberProfilePatchRequestDto.is_alarm_allowed() != null) {
             existingMember.updateMemberIsAlarmAllowed(memberProfilePatchRequestDto.is_alarm_allowed());
         }
-
         // 저장
         Member savedMember = memberRepository.save(existingMember);
+    }
+
+    public void updateMemberProfile2(Long memberId, MultipartFile multipartFile, ProfilePatchRequestDto profilePatchRequestDto) {
+        Member existingMember = memberRepository.findMemberByIdOrThrow(memberId);
+
+        // 업데이트할 속성만 복사
+        if (profilePatchRequestDto.nickname() != null) {
+            existingMember.updateNickname(profilePatchRequestDto.nickname());
+        }
+        if (profilePatchRequestDto.memberIntro() != null) {
+            existingMember.updateMemberIntro(profilePatchRequestDto.memberIntro());
+        }
+        //이미지를 받았을 경우 S3에 업로드하고, memberTable값 수정하고, 이전에 올라갔던 이미지는 S3에서 삭제
+        //이때 기본 이미지였다면 삭제 과정은 스킵. 현재는 깃허브에 올라간 사진이라서 사라지지 않지만, 추후 기본 이미지를 우리 S3에 올릴 것을 대비.
+        if (!multipartFile.isEmpty()) {
+            String existedImage = existingMember.getProfileUrl();
+
+            try {
+                String s3ImageUrl = s3Service.uploadImage(memberId.toString(), multipartFile);
+                existingMember.updateProfileUrl(s3ImageUrl);
+
+                if(!existedImage.equals(GHOST_IMAGE)) {
+                    String existedKey = removeBaseUrl(existedImage, S3_URL);
+                    s3Service.deleteImage(existedKey);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e.getMessage());
+            }
+        }
+        if (profilePatchRequestDto.isAlarmAllowed() != null) {
+            existingMember.updateMemberIsAlarmAllowed(profilePatchRequestDto.isAlarmAllowed());
+        }
+        Member savedMember = memberRepository.save(existingMember);
+    }
+
+    private static String removeBaseUrl(String fullUrl, String baseUrl) {
+        if (fullUrl.startsWith(baseUrl)) {
+            return fullUrl.substring(baseUrl.length());
+        } else {
+            return fullUrl; // baseUrl이 존재하지 않는 경우 전체 URL 반환
+        }
     }
 }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
@@ -19,6 +19,7 @@ import com.dontbe.www.DontBeServer.api.notification.repository.NotificationRepos
 import com.dontbe.www.DontBeServer.api.notification.domain.Notification;
 import com.dontbe.www.DontBeServer.external.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -40,8 +41,13 @@ public class MemberCommandService {
     private final S3Service s3Service;
     private final String DEFAULT_PROFILE_URL = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
     private final static String GHOST_IMAGE = "https://github.com/TeamDon-tBe/SERVER/assets/97835512/fb3ea04c-661e-4221-a837-854d66cdb77e";
-    private final static String GHOST_IMAGE_S3 = "https://dontbe-s3.s3.ap-northeast-2.amazonaws.com/ProfileImage/defalut/image_profile.png";
-    private static final String S3_URL = "https://dontbe-s3.s3.ap-northeast-2.amazonaws.com/";
+
+    @Value("${aws-property.s3-default-image-url}")
+    private String GHOST_IMAGE_S3;
+
+    @Value("${aws-property.s3-domain}")
+    private String S3_URL;
+
     public void withdrawalMember(Long memberId, MemberWithdrawRequestDto memberWithdrawRequestDto) {
         Member member = memberRepository.findMemberByIdOrThrow(memberId);
         List<Ghost> ghosts = ghostRepository.findByGhostTargetMember(member);

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/common/response/ErrorStatus.java
@@ -26,6 +26,9 @@ public enum ErrorStatus {
     GHOST_MYSELF_BLOCK("본인의 투명도를 내릴 수 없습니다."),
     GHOST_USER("투명도가 -85이하라서 글이나 답글을 작성할 수 없습니다."),
     WITHDRAWAL_MEMBER("계정 삭제 후 30일 이내 회원입니다."),
+    UNVALID_PROFILEIMAGE_TYPE("이미지 확장자는 jpg, png, webp만 가능합니다."),
+    PROFILE_IMAGE_DATA_SIZE("이미지 사이즈는 5MB를 넘을 수 없습니다."),
+
 
     /**
      * 401 UNAUTHORIZED

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/external/s3/config/AWSConfig.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/external/s3/config/AWSConfig.java
@@ -1,0 +1,47 @@
+package com.dontbe.www.DontBeServer.external.s3.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AWSConfig {
+
+    private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String AWS_SECRET_ACCESS_KEY = "aws.secretAccessKey";
+
+    private final String accessKey;
+    private final String secretKey;
+    private final String regionString;
+
+    public AWSConfig(@Value("${aws-property.access-key}") final String accessKey,
+                     @Value("${aws-property.secret-key}") final String secretKey,
+                     @Value("${aws-property.aws-region}") final String regionString) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.regionString = regionString;
+    }
+
+    @Bean
+    public SystemPropertyCredentialsProvider systemPropertyCredentialsProvider() {
+        System.setProperty(AWS_ACCESS_KEY_ID, accessKey);
+        System.setProperty(AWS_SECRET_ACCESS_KEY, secretKey);
+        return SystemPropertyCredentialsProvider.create();
+    }
+
+    @Bean
+    public Region getRegion() {
+        return Region.of(regionString);
+    }
+
+    @Bean
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(getRegion())
+                .credentialsProvider(systemPropertyCredentialsProvider())
+                .build();
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/external/s3/service/S3Service.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/external/s3/service/S3Service.java
@@ -1,0 +1,80 @@
+package com.dontbe.www.DontBeServer.external.s3.service;
+
+import com.dontbe.www.DontBeServer.external.s3.config.AWSConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class S3Service {
+
+    private static final String S3_URL = "https://dontbe-s3.s3.ap-northeast-2.amazonaws.com/";
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+    private static final Long MAX_FILE_SIZE = 5 * 1024 * 1024L;
+
+    private final String bucketName;
+    private final AWSConfig awsConfig;
+
+    public S3Service(@Value("${aws-property.s3-bucket-name}") final String bucketName, AWSConfig awsConfig) {
+        this.bucketName = bucketName;
+        this.awsConfig = awsConfig;
+    }
+
+
+    public String uploadImage(String directoryPath, MultipartFile image) throws IOException {
+        validateExtension(image);
+        validateFileSize(image);
+
+        final String key = "ProfileImage/" + directoryPath + "/" + generateImageFileName();
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+        s3Client.putObject(request, requestBody);
+        return S3_URL + key;
+    }
+
+    public void deleteImage(String key) {
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        s3Client.deleteObject((DeleteObjectRequest.Builder builder) ->
+                builder.bucket(bucketName)
+                        .key(key)
+                        .build()
+        );
+    }
+
+
+    private String generateImageFileName() {
+        return UUID.randomUUID().toString() + ".jpg";
+    }
+
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new RuntimeException("이미지 확장자는 jpg, png, webp만 가능합니다.");
+        }
+    }
+
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new RuntimeException("이미지 사이즈는 5MB를 넘을 수 없습니다.");
+        }
+    }
+
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/external/s3/service/S3Service.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/external/s3/service/S3Service.java
@@ -1,5 +1,6 @@
 package com.dontbe.www.DontBeServer.external.s3.service;
 
+import com.dontbe.www.DontBeServer.common.response.ErrorStatus;
 import com.dontbe.www.DontBeServer.external.s3.config.AWSConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -67,14 +68,13 @@ public class S3Service {
     private void validateExtension(MultipartFile image) {
         String contentType = image.getContentType();
         if (!IMAGE_EXTENSIONS.contains(contentType)) {
-            throw new RuntimeException("이미지 확장자는 jpg, png, webp만 가능합니다.");
+            throw new RuntimeException(ErrorStatus.UNVALID_PROFILEIMAGE_TYPE.getMessage());
         }
     }
 
     private void validateFileSize(MultipartFile image) {
         if (image.getSize() > MAX_FILE_SIZE) {
-            throw new RuntimeException("이미지 사이즈는 5MB를 넘을 수 없습니다.");
+            throw new RuntimeException(ErrorStatus.PROFILE_IMAGE_DATA_SIZE.getMessage());
         }
     }
-
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #156 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 프로필 수정하기, 덮어쓰기 API에 대해서 프로필 이미지를 multipart형식으로 제공받으면 해당 이미지를 S3에 올린 후에 해당 이미지에 접근할 수 있는 URL을 반환받고, 그것을 member테이블에 저장하는 기능을 추가했습니다.
* 해당 과정에서 그전에 있던 이미지는 S3에서 삭제하게 로직을 구현했습니다. 이때 기본이미지였다면 삭제과정은 스킵하게 했습니다.
* S3에 파일이 올라갈 때는 memberprofile/{memberId}/image.png와 같은 경로로 저장되게 코드를 작성했습니다.
* requestBody를 multipart형식으로 받다보니 postman에서도 형식이 다릅니다. 이에 대해 아래에 예시 첨부합니다.
* multipart로 받는 이미지의 크기 제한이 기본으로 1MB라고 하여 이 부분 수정하는 스크립트 APPLICATION.YAML에 추가했습니다.
* nginx에서의 기본 제한도 1MB리고 하여 이 부분 수정하고 restart진행했습니다.
* APPLICATION.YAML파일에 내용 수정이 있어서 깃엑션 시크릿 키 수정했습니다. 로컬에 대해서는 추후 따로 공유드리겠습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1597" alt="스크린샷 2024-02-21 오전 5 28 57" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/895dcdf6-3211-4289-b8aa-ca504206553e">
<img width="793" alt="스크린샷 2024-02-21 오전 5 45 23" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/d38ff739-101e-45e8-a624-d23317eef811">
<img width="1138" alt="스크린샷 2024-02-21 오전 5 29 12" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/49f41b91-06f1-4d57-bf4d-f5f66d1167e9">
<img width="1305" alt="스크린샷 2024-02-21 오전 5 25 53" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/8fc290fa-f6aa-4dbd-9104-3611a9d391b8">
