### PR TITLE
[FIX] 계정삭제 api 메소드 변경

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.dontbe.www.DontBeServer.api.member.controller;
 
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberProfilePatchRequestDto;
-import com.dontbe.www.DontBeServer.api.member.dto.request.MemberWithdrawRequestDto;
+import com.dontbe.www.DontBeServer.api.member.dto.request.MemberWithdrawalPatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.request.ProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberDetailGetResponseDto;
 import com.dontbe.www.DontBeServer.api.member.dto.response.MemberGetProfileResponseDto;
@@ -32,9 +32,9 @@ public class MemberController {
 
     @DeleteMapping("withdrawal")
     @Operation(summary = "계정 삭제 API입니다.",description = "MemberWithdrawal")
-    public ResponseEntity<ApiResponse<Object>> withdrawalMember(Principal principal, @RequestBody MemberWithdrawRequestDto memberWithdrawRequestDto) {
+    public ResponseEntity<ApiResponse<Object>> withdrawalMember(Principal principal, @RequestBody MemberWithdrawalPatchRequestDto memberWithdrawalPatchRequestDto) {
         Long memberId = MemberUtil.getMemberId(principal);
-        memberCommandService.withdrawalMember(memberId, memberWithdrawRequestDto);
+        memberCommandService.withdrawalMember(memberId, memberWithdrawalPatchRequestDto);
         return ApiResponse.success(WITHDRAWAL_SUCCESS);
     }
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/controller/MemberController.java
@@ -30,7 +30,7 @@ public class MemberController {
     private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
 
-    @DeleteMapping("withdrawal")
+    @PatchMapping("withdrawal")
     @Operation(summary = "계정 삭제 API입니다.",description = "MemberWithdrawal")
     public ResponseEntity<ApiResponse<Object>> withdrawalMember(Principal principal, @RequestBody MemberWithdrawalPatchRequestDto memberWithdrawalPatchRequestDto) {
         Long memberId = MemberUtil.getMemberId(principal);

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/request/MemberWithdrawRequestDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/request/MemberWithdrawRequestDto.java
@@ -1,6 +1,0 @@
-package com.dontbe.www.DontBeServer.api.member.dto.request;
-
-public record MemberWithdrawRequestDto(
-        String withdrawalReason
-) {
-}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/request/MemberWithdrawalPatchRequestDto.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/dto/request/MemberWithdrawalPatchRequestDto.java
@@ -1,0 +1,6 @@
+package com.dontbe.www.DontBeServer.api.member.dto.request;
+
+public record MemberWithdrawalPatchRequestDto(
+        String deleted_reason
+) {
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
@@ -12,7 +12,7 @@ import com.dontbe.www.DontBeServer.api.content.repository.ContentLikedRepository
 import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
 import com.dontbe.www.DontBeServer.api.member.domain.Member;
 import com.dontbe.www.DontBeServer.api.member.dto.request.MemberProfilePatchRequestDto;
-import com.dontbe.www.DontBeServer.api.member.dto.request.MemberWithdrawRequestDto;
+import com.dontbe.www.DontBeServer.api.member.dto.request.MemberWithdrawalPatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.dto.request.ProfilePatchRequestDto;
 import com.dontbe.www.DontBeServer.api.member.repository.MemberRepository;
 import com.dontbe.www.DontBeServer.api.notification.repository.NotificationRepository;
@@ -48,13 +48,13 @@ public class MemberCommandService {
     @Value("${aws-property.s3-domain}")
     private String S3_URL;
 
-    public void withdrawalMember(Long memberId, MemberWithdrawRequestDto memberWithdrawRequestDto) {
+    public void withdrawalMember(Long memberId, MemberWithdrawalPatchRequestDto memberWithdrawalPatchRequestDto) {
         Member member = memberRepository.findMemberByIdOrThrow(memberId);
         List<Ghost> ghosts = ghostRepository.findByGhostTargetMember(member);
 
         member.updateNickname("탈퇴한 회원");
         member.updateProfileUrl(DEFAULT_PROFILE_URL);
-        member.updateDeletedReason(memberWithdrawRequestDto.withdrawalReason());
+        member.updateDeletedReason(memberWithdrawalPatchRequestDto.deleted_reason());
 
         notificationRepository.deleteBynotificationTargetMember(member);
         for(Ghost ghost:ghosts){ ghost.softDelete(); }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #168 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
delete 메소드에 requestBody 담지 못하기 때문에 메소드를 patch로 변경했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
계정의 실질적인 삭제는 30일 이후 cron 기능으로 삭제되기 때문에 메소드로 delete를 사용하는 것은 적절하지 않다고 생각했습니다! 계정 삭제 사유를 받아 부분적으로 업데이트를 하는 것이 계정삭제 api의 목적이라고 생각하기 때문에 patch 메소드로 변경했습니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/c7f4c406-9090-4a43-9e50-9c3e558704f3)
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/8d0b73d4-3620-4450-bbc1-94d77fce9f21)
