### PR TITLE
[FEAT]프로필 수정하기에서 이미지 null허용 로직 추가

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/member/service/MemberCommandService.java
@@ -140,7 +140,7 @@ public class MemberCommandService {
         }
         //이미지를 받았을 경우 S3에 업로드하고, memberTable값 수정하고, 이전에 올라갔던 이미지는 S3에서 삭제
         //이때 기본 이미지였다면 삭제 과정은 스킵. 현재는 깃허브에 올라간 사진이라서 사라지지 않지만, 추후 기본 이미지를 우리 S3에 올릴 것을 대비.
-        if (!multipartFile.isEmpty()) {
+        if (multipartFile != null && !multipartFile.isEmpty()) {
             String existedImage = existingMember.getProfileUrl();
 
             try {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #170

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 찬우형의 요청으로 프로필 수정하기 API에서 프로필을 null로 보내도 이를 허용하는 로직을 추가합니다.
  * 이때 null이라는 것은 file항목의 값이 null이 아닌 아예 file항목을 안보내는 경우를 의미합니다.
  * 일단 새벽이라 찬우형이 급하게 요청하신 것 같아서 byPass합니다. 추후 확인 부탁드려요~

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1302" alt="스크린샷 2024-02-26 오전 4 24 22" src="https://github.com/TeamDon-tBe/SERVER/assets/97835512/ae312121-acfd-4452-b0de-897d6cc7878a">

