### PR TITLE
[feat] response에 isDeleted가 추가된 게시물 상세조회 api ver2 구현

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
@@ -21,34 +21,34 @@ import static com.dontbe.www.DontBeServer.common.response.SuccessStatus.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1")
+@RequestMapping("api/")
 @SecurityRequirement(name = "JWT Auth")
 @Tag(name="게시글 관련", description = "Content API Document")
 public class ContentController {
     private final ContentCommandService contentCommandService;
     private final ContentQueryService contentQueryService;
 
-    @PostMapping("content")
+    @PostMapping("v1/content")
     @Operation(summary = "게시글 작성 API 입니다.",description = "Content Post")
     public ResponseEntity<ApiResponse<Object>> postContent(Principal principal, @Valid @RequestBody ContentPostRequestDto contentPostRequestDto) {
         contentCommandService.postContent(MemberUtil.getMemberId(principal),contentPostRequestDto);
         return ApiResponse.success(POST_CONTENT_SUCCESS);
     }
 
-    @DeleteMapping("content/{contentId}")
+    @DeleteMapping("v1/content/{contentId}")
     @Operation(summary = "게시글 삭제 API 입니다.",description = "Content Delete")
     public ResponseEntity<ApiResponse<Object>> deleteContent(Principal principal, @PathVariable("contentId") Long contentId) {
         contentCommandService.deleteContent(MemberUtil.getMemberId(principal),contentId);
         return ApiResponse.success(DELETE_CONTENT_SUCCESS);
     }
 
-    @GetMapping("content/{contentId}/detail")
+    @GetMapping("v1/content/{contentId}/detail")
     @Operation(summary = "게시글 상세 조회 API 입니다.",description = "Content Get Detail")
     public ResponseEntity<ApiResponse<ContentGetDetailsResponseDto>> getContentDetail(Principal principal, @PathVariable("contentId") Long contentId) {
         return ApiResponse.success(GET_CONTENT_DETAIL_SUCCESS, contentQueryService.getContentDetail(MemberUtil.getMemberId(principal), contentId));
     }
 
-    @PostMapping("content/{contentId}/liked")
+    @PostMapping("v1/content/{contentId}/liked")
     @Operation(summary = "게시글 좋아요 API 입니다.",description = "Content Like")
     public ResponseEntity<ApiResponse<Object>> likeContent(Principal principal, @PathVariable("contentId") Long contentId, @Valid @RequestBody ContentLikedRequestDto contentLikedRequestDto) {
         Long memberId = MemberUtil.getMemberId(principal);
@@ -56,7 +56,7 @@ public class ContentController {
         return ApiResponse.success(CONTENT_LIKE_SUCCESS);
     }
 
-    @DeleteMapping("content/{contentId}/unliked")
+    @DeleteMapping("v1/content/{contentId}/unliked")
     @Operation(summary = "게시글 좋아요 취소 API 입니다.",description = "Content Unlike")
     public ResponseEntity<ApiResponse<Object>> unlikeContent(Principal principal, @PathVariable("contentId") Long contentId) {
         Long memberId = MemberUtil.getMemberId(principal);
@@ -64,28 +64,28 @@ public class ContentController {
         return ApiResponse.success(CONTENT_UNLIKE_SUCCESS);
     }
 
-    @GetMapping("content/all")   //페이지네이션 적용 후 지우기
+    @GetMapping("v1/content/all")   //페이지네이션 적용 후 지우기
     @Operation(summary = "게시글 전체 조회 API 입니다.",description = "ContentGetAll")
     public ResponseEntity<ApiResponse<List<ContentGetAllResponseDto>>> getContentAll(Principal principal) {
         Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponse.success(GET_CONTENT_ALL_SUCCESS, contentQueryService.getContentAll(memberId));
     }
 
-    @GetMapping("member/{memberId}/contents")   //페이지네이션 적용 후 지우기
+    @GetMapping("v1/member/{memberId}/contents")   //페이지네이션 적용 후 지우기
     @Operation(summary = "멤버에 해당하는 게시글 조회 API 입니다.",description = "ContentGetAllByMember")
     public ResponseEntity<ApiResponse<List<ContentGetAllByMemberResponseDto>>> getContentAllByMember(Principal principal, @PathVariable("memberId") Long targetMemberId) {
         Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponse.success(GET_CONTENT_ALL_SUCCESS, contentQueryService.getContentAllByMember(memberId, targetMemberId));
     }
 
-    @GetMapping("/contents")
+    @GetMapping("v1/contents")
     @Operation(summary = "페이지네이션이 적용된 게시글 전체 조회 API 입니다.",description = "ContentGetPagination")
     public ResponseEntity<ApiResponse<List<ContentGetAllResponseDtoVer2>>> getContentAllPagination(Principal principal, @RequestParam(value = "cursor") Long cursor) {
         Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponse.success(GET_CONTENT_ALL_SUCCESS, contentQueryService.getContentAllPagination(memberId, cursor));
     }
 
-    @GetMapping("/member/{memberId}/member-contents")
+    @GetMapping("v1/member/{memberId}/member-contents")
     @Operation(summary = "페이지네이션이 적용된 멤버에 해당하는 게시글 리스트 조회 API 입니다.",description = "ContentByMemberPagination")
     public ResponseEntity<ApiResponse<List<ContentGetAllByMemberResponseDto>>> getContentAllByMemberPagination(Principal principal,
                                                                                                      @PathVariable("memberId") Long targetMemberId,  @RequestParam(value = "cursor") Long cursor) {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
@@ -48,6 +48,12 @@ public class ContentController {
         return ApiResponse.success(GET_CONTENT_DETAIL_SUCCESS, contentQueryService.getContentDetail(MemberUtil.getMemberId(principal), contentId));
     }
 
+    @GetMapping("v2/content/{contentId}/detail")
+    @Operation(summary = "isDeleted가 추가된 게시글 상세 조회 API 입니다.",description = "Content Get Detail")
+    public ResponseEntity<ApiResponse<ContentGetDetailsResponseDtoVer2>> getContentDetailVer2(Principal principal, @PathVariable("contentId") Long contentId) {
+        return ApiResponse.success(GET_CONTENT_DETAIL_SUCCESS, contentQueryService.getContentDetailVer2(MemberUtil.getMemberId(principal), contentId));
+    }
+
     @PostMapping("v1/content/{contentId}/liked")
     @Operation(summary = "게시글 좋아요 API 입니다.",description = "Content Like")
     public ResponseEntity<ApiResponse<Object>> likeContent(Principal principal, @PathVariable("contentId") Long contentId, @Valid @RequestBody ContentLikedRequestDto contentLikedRequestDto) {

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/controller/ContentController.java
@@ -49,7 +49,7 @@ public class ContentController {
     }
 
     @GetMapping("v2/content/{contentId}/detail")
-    @Operation(summary = "isDeleted가 추가된 게시글 상세 조회 API 입니다.",description = "Content Get Detail")
+    @Operation(summary = "isDeleted가 추가된 게시글 상세 조회 API 입니다.",description = "Content Get Detail ver2")
     public ResponseEntity<ApiResponse<ContentGetDetailsResponseDtoVer2>> getContentDetailVer2(Principal principal, @PathVariable("contentId") Long contentId) {
         return ApiResponse.success(GET_CONTENT_DETAIL_SUCCESS, contentQueryService.getContentDetailVer2(MemberUtil.getMemberId(principal), contentId));
     }

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/dto/response/ContentGetDetailsResponseDtoVer2.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/dto/response/ContentGetDetailsResponseDtoVer2.java
@@ -1,0 +1,34 @@
+package com.dontbe.www.DontBeServer.api.content.dto.response;
+
+import com.dontbe.www.DontBeServer.api.content.domain.Content;
+import com.dontbe.www.DontBeServer.api.member.domain.Member;
+
+public record ContentGetDetailsResponseDtoVer2(
+        Long memberId,
+        String memberProfileUrl,
+        String memberNickname,
+        boolean isGhost,
+        int memberGhost,
+        boolean isLiked,
+        String time,
+        int likedNumber,
+        int commentNumber,
+        String contentText,
+        Boolean isDeleted
+) {
+    public static ContentGetDetailsResponseDtoVer2 of(Member member, int memberGhost, Content content, boolean isGhost, boolean isLiked, String time, int likedNumber, int commentNumber){
+        return new ContentGetDetailsResponseDtoVer2(
+                member.getId(),
+                member.getProfileUrl(),
+                member.getNickname(),
+                isGhost,
+                memberGhost,
+                isLiked,
+                time,
+                likedNumber,
+                commentNumber,
+                content.getContentText(),
+                member.isDeleted()
+        );
+    }
+}

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentQueryService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentQueryService.java
@@ -2,10 +2,7 @@ package com.dontbe.www.DontBeServer.api.content.service;
 
 import com.dontbe.www.DontBeServer.api.comment.repository.CommentRepository;
 import com.dontbe.www.DontBeServer.api.content.domain.Content;
-import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetAllByMemberResponseDto;
-import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetAllResponseDto;
-import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetAllResponseDtoVer2;
-import com.dontbe.www.DontBeServer.api.content.dto.response.ContentGetDetailsResponseDto;
+import com.dontbe.www.DontBeServer.api.content.dto.response.*;
 import com.dontbe.www.DontBeServer.api.content.repository.ContentLikedRepository;
 import com.dontbe.www.DontBeServer.api.content.repository.ContentRepository;
 import com.dontbe.www.DontBeServer.api.ghost.repository.GhostRepository;
@@ -46,6 +43,21 @@ public class ContentQueryService {
         int commentNumber = commentRepository.countByContent(content);
 
         return ContentGetDetailsResponseDto.of(writerMember, writerMemberGhost, content, isGhost, isLiked, time, likedNumber, commentNumber);
+    }
+
+    public ContentGetDetailsResponseDtoVer2 getContentDetailVer2(Long memberId, Long contentId) {
+        Member member = memberRepository.findMemberByIdOrThrow(memberId);
+        Content content = contentRepository.findContentByIdOrThrow(contentId);
+        Member writerMember = memberRepository.findMemberByIdOrThrow(content.getMember().getId());
+        int writerMemberGhost = GhostUtil.refineGhost(writerMember.getMemberGhost());
+        Long writerMemberId = content.getMember().getId();
+        boolean isGhost = ghostRepository.existsByGhostTargetMemberIdAndGhostTriggerMemberId(writerMemberId, memberId);
+        boolean isLiked = contentLikedRepository.existsByContentAndMember(content,member);
+        String time = TimeUtilCustom.refineTime(content.getCreatedAt());
+        int likedNumber = contentLikedRepository.countByContent(content);
+        int commentNumber = commentRepository.countByContent(content);
+
+        return ContentGetDetailsResponseDtoVer2.of(writerMember, writerMemberGhost, content, isGhost, isLiked, time, likedNumber, commentNumber);
     }
 
     public List<ContentGetAllResponseDto> getContentAll(Long memberId) {    //페이지네이션 적용 후 지우기


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #174 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
게시물 상세조회 api에도 탈퇴한 유저인지 구분하는 isDeleted값을 추가하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
contentcontroller 버전 분리하고 v2 도입하였습니다! 
[명세서](https://www.notion.so/ver2-2dca59d806b140de982c3d75e35e9fc2) 추가했습니다!

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
![image](https://github.com/TeamDon-tBe/SERVER/assets/128011308/942c9091-0b58-42bf-b62d-1d24a30b3e34)
