### PR TITLE
[FEAT] 계정삭제api에 soft delete 재적용 

### DIFF
--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentCommendService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/comment/service/CommentCommendService.java
@@ -66,9 +66,9 @@ public class CommentCommendService {
         notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("comment",commentId);
         notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost", commentId);
 
-        //Comment deleteComment = commentRepository.findCommentByIdOrThrow(commentId);
-        //deleteComment.softDelete();
-        commentRepository.deleteById(commentId);
+        Comment deleteComment = commentRepository.findCommentByIdOrThrow(commentId);
+        deleteComment.softDelete();
+
 
     }
 

--- a/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
+++ b/DontBeServer/src/main/java/com/dontbe/www/DontBeServer/api/content/service/ContentCommandService.java
@@ -51,13 +51,13 @@ public class ContentCommandService {
             notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("commentGhost",comment.getId());
             notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("comment", comment.getId());
 
-            //comment.softDelete();
+            comment.softDelete();
         }
         notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("contentLiked",contentId);
         notificationRepository.deleteByNotificationTriggerTypeAndNotificationTriggerId("contentGhost",contentId);
 
-        //Content deleteContent = contentRepository.findContentByIdOrThrow(contentId);
-        //deleteContent.softDelete();
+        Content deleteContent = contentRepository.findContentByIdOrThrow(contentId);
+        deleteContent.softDelete();
         contentRepository.deleteById(contentId);
     }
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #182

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
앱 심사용 탈퇴하기 api와 실제 사용하는 계정 삭제 api의 충돌로 soft delete 주석처리해놓았던 부분을 다시 재적용합니다.
어프루브 받고 기다렸다가 아요 테플에서 어플 내려가는 순간 머지할 예정입니다!

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
